### PR TITLE
added skipUTurns argument

### DIFF
--- a/src/main/java/com/graphhopper/matching/MapMatchingMain.java
+++ b/src/main/java/com/graphhopper/matching/MapMatchingMain.java
@@ -71,6 +71,7 @@ public class MapMatchingMain {
             mapMatching.setSeparatedSearchDistance(args.getInt("separatedSearchDistance", 500));
             mapMatching.setMaxSearchMultiplier(args.getInt("maxSearchMultiplier", 100));
             mapMatching.setForceRepair(args.getBool("forceRepair", false));
+            mapMatching.setSkipUTurns(args.getBool("skipUTurns", true));
 
             // do the actual matching, get the GPX entries from a file or via stream
             String gpxLocation = args.get("gpx", "");

--- a/src/main/java/com/graphhopper/matching/TempMatchResult.java
+++ b/src/main/java/com/graphhopper/matching/TempMatchResult.java
@@ -1,0 +1,19 @@
+package com.graphhopper.matching;
+
+import com.sun.org.apache.xerces.internal.impl.xpath.regex.Match;
+
+import java.util.List;
+
+public class TempMatchResult {
+    private MatchResult matchResult;
+    private int endIndex;
+
+    public TempMatchResult(MatchResult edgeMatches, int endIndex) {
+
+        this.matchResult = edgeMatches;
+        this.endIndex = endIndex;
+    }
+
+    public MatchResult getMatchResult() { return matchResult; }
+    public int getEndIndex() { return endIndex; }
+}


### PR DESCRIPTION
Map-matching can be restarted when u-turn is detected. I know this is not a complete solution for handling loops. For my use case this together with separatedSearchDistance seems to be enough for now and I decided to make a pull request if this is useful for others aswell.

I have some errors (all asserts pass) with tests related to the orientation fix (flipping an edge). @karussell can you comment on that, if there is some easy way to fix that or am I completely misunderstood how that orientation fix should be applied.