### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ hopper.setEncodingManager(new EncodingManager(encoder));
 hopper.setCHEnable(false);
 hopper.importOrLoad();
 
-// create MapMatching object, can and should be shared accross threads
+// create MapMatching object, can and should be shared across threads
 
 GraphStorage graph = hopper.getGraph();
 LocationIndexMatch locationIndex = new LocationIndexMatch(graph,


### PR DESCRIPTION
@graphhopper, I've corrected a typographical error in the documentation of the [map-matching](https://github.com/graphhopper/map-matching) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.