### PR TITLE
VCS: add IDEA and Eclipse files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ test.gpx
 graph-cache/
 nbactions.xml
 *pbf
+.idea/
+*iml
+.settings/
+.classpath
+.project


### PR DESCRIPTION
Add IDEA and Eclipse project files to `.gitignore` needed for VCS.