### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/matching-core/src/main/java/com/graphhopper/matching/GPXExtension.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/GPXExtension.java
@@ -26,7 +26,7 @@ import com.graphhopper.util.GPXEntry;
  */
 public class GPXExtension
 {
-    final GPXEntry entry;
+    private final GPXEntry entry;
     final QueryResult queryResult;
     final int gpxListIndex;
 

--- a/matching-core/src/main/java/com/graphhopper/matching/GPXFile.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/GPXFile.java
@@ -45,9 +45,9 @@ import org.w3c.dom.NodeList;
  */
 public class GPXFile {
 
-    static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
-    static final String DATE_FORMAT_Z = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-    static final String DATE_FORMAT_Z_MS = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
+    private static final String DATE_FORMAT_Z = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    private static final String DATE_FORMAT_Z_MS = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     private final List<GPXEntry> entries;
     private final boolean includeElevation = false;
     private InstructionList instructions;

--- a/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
@@ -478,7 +478,7 @@ public class MapMatching {
 
     private static class DoubleRef {
 
-        double value;
+        private double value;
 
         public DoubleRef(double value) {
             this.value = value;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat