### PR TITLE
Use bash for map-matching.sh

### DIFF
--- a/map-matching.sh
+++ b/map-matching.sh
@@ -1,4 +1,4 @@
-
+#!/bin/bash
 
 if [ "$JAVA" = "" ]; then
  JAVA=java


### PR DESCRIPTION
On certain systems dash is the default when running ./map-matching.sh resulting in `Syntax error`