### PR TITLE
added find radial method to address #65

### DIFF
--- a/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
@@ -145,7 +145,7 @@ public class MapMatching {
                     || distanceCalc.calcDist(previous.getLat(), previous.getLon(), entry.getLat(), entry.getLon()) > 2 * measurementErrorSigma
                     // always include last point
                     || indexGPX == gpxList.size() - 1) {
-                List<QueryResult> candidates = locationIndex.findNClosest(entry.lat, entry.lon, edgeFilter, measurementErrorSigma);
+                List<QueryResult> candidates = locationIndex.findEdgesWithinRadius(entry.lat, entry.lon, edgeFilter, measurementErrorSigma);
                 allCandidates.addAll(candidates);
                 List<GPXExtension> gpxExtensions = new ArrayList<GPXExtension>();
                 for (QueryResult candidate : candidates) {

--- a/matching-core/src/test/java/com/graphhopper/matching/LocationIndexMatchTest.java
+++ b/matching-core/src/test/java/com/graphhopper/matching/LocationIndexMatchTest.java
@@ -84,7 +84,7 @@ public class LocationIndexMatchTest {
         LocationIndexMatch index = new LocationIndexMatch(ghStorage, tmpIndex);
 
         // query node 4 => get at least 4-5, 4-7
-        List<QueryResult> result = index.findNClosest(0.0004, 0.0006, EdgeFilter.ALL_EDGES, 15);
+        List<QueryResult> result = index.findEdgesWithinRadius(0.0004, 0.0006, EdgeFilter.ALL_EDGES, 15);
         List<Integer> ids = new ArrayList<Integer>();
         for (QueryResult qr : result) {
             ids.add(qr.getClosestEdge().getEdge());


### PR DESCRIPTION
See discussion at #65. 

Notes:
- this is my first pull request (ever), so apologies if I've done something silly! Feel free to let me know how things work best for you guys, as I've got no idea.
- I'm also new to Java.
- I doubt many people will need the `minDistance` feature (though I do, for cell network stuff where we only know a radius as opposed to a point). It's easy to keep, so I figure there's no harm.
- I've had to tweak the tests to get them working. I think they're more "correct" now. (Generally they're to do with setting the "correct" measurementSigmaError.) However, please check!
- I'm not sure how fast it is. I imagine it'll be comparable to the old method (assuming similar measurementSigmaError), as even for a maxRadius of zero, it'll still search 9 tiles.
- it's probably not 100% accuracte in that it's probably possible for e.g. an edge to have a minimum distance less than minRadius (so excluded), but for part of the edge to be outside minRadius (so it should be included).
- similarly, it can probably be refactored further down so that instead of relying on the closest edge distance (which presumably requires looping through all line segments of and egde and calculating their distance), to just loop through until it meets the first line segment that satisfies the condition.

@karussell, am I correct with the last two points?
