### PR TITLE
Allow map matching to use CH too

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,5 +4,6 @@
  * michaz, very important hidden markov improvement via hmm-lib, see #49
  * rory, support milisecond gpx timestamps, see #4 
  * stefanholder, via creating and integrating the hmm-lib (!), see #49, #66 and #69
+ * kodonnell, adding support for CH and other algorithms as per #60
 
 For GraphHopper contributors see [here](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTORS.md).

--- a/matching-core/pom.xml
+++ b/matching-core/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
@@ -17,21 +17,24 @@
  */
 package com.graphhopper.matching;
 
+import com.graphhopper.GraphHopper;
 import com.graphhopper.matching.util.HmmProbabilities;
 import com.graphhopper.matching.util.TimeStep;
-import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.bmw.hmm.SequenceState;
 import com.bmw.hmm.ViterbiAlgorithm;
-import com.graphhopper.routing.DijkstraBidirectionRef;
+import com.graphhopper.routing.AlgorithmOptions;
 import com.graphhopper.routing.Path;
 import com.graphhopper.routing.QueryGraph;
+import com.graphhopper.routing.RoutingAlgorithm;
+import com.graphhopper.routing.RoutingAlgorithmFactory;
 import com.graphhopper.routing.util.*;
+import com.graphhopper.storage.CHGraph;
 import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -54,44 +57,40 @@ import java.util.Map;
  * @author Peter Karich
  * @author Michael Zilske
  * @author Stefan Holder
+ * @author kodonnell
  */
 public class MapMatching {
 
     private final Graph graph;
     private final LocationIndexMatch locationIndex;
-    private final FlagEncoder encoder;
-    private final TraversalMode traversalMode;
-
+	private final FlagEncoder encoder;
     private double measurementErrorSigma = 50.0;
-
     private double transitionProbabilityBeta = 0.00959442;
-    private int maxVisitedNodes = 1000;
     private final int nodeCount;
     private DistanceCalc distanceCalc = new DistancePlaneProjection();
-    private Weighting weighting;
+	private RoutingAlgorithmFactory algoFactory;
+	private AlgorithmOptions algoOptions;
+	private Weighting weighting;
+	
 
-    public MapMatching(Graph graph, LocationIndexMatch locationIndex, FlagEncoder encoder) {
-        this.graph = graph;
-        this.nodeCount = graph.getNodes();
-        this.locationIndex = locationIndex;
-
-        // TODO initialization of start values for the algorithm is currently done explicitly via
-        // node IDs!
-        // To fix this use instead: traversalMode.createTraversalId(iter, false);
-//        this.traversalMode = graph.getExtension() instanceof TurnCostExtension
-//                ? TraversalMode.EDGE_BASED_2DIR : TraversalMode.NODE_BASED;
-        this.traversalMode = TraversalMode.NODE_BASED;
-        this.encoder = encoder;
-        this.weighting = new FastestWeighting(encoder);
+    public MapMatching(GraphHopper hopper, AlgorithmOptions algoOptions) {
+    	
+    	this.locationIndex = new LocationIndexMatch(hopper.getGraphHopperStorage(), (LocationIndexTree) hopper.getLocationIndex());
+    	this.encoder = algoOptions.getFlagEncoder();
+    	this.weighting = algoOptions.getWeighting();
+    	// get base graph, which differs depending on CH:
+    	this.graph = hopper.getGraphHopperStorage().getGraph((hopper.isCHEnabled() ? CHGraph.class : Graph.class), this.weighting);
+    	this.nodeCount = graph.getNodes();
+        this.algoOptions = algoOptions;
+        // create hints from algoOptions, so we can create the algorithm factory
+    	PMap pmap = algoOptions.getHints();
+    	HintsMap hints = new HintsMap();    	
+    	for (String k: pmap.toMap().keySet()) {
+    		hints.put(k, pmap.get(k, null));
+    	}
+        this.algoFactory = hopper.getAlgorithmFactory(hints);   
     }
-
-    /**
-     * This method overwrites the default fastest weighting.
-     */
-    public void setWeighting(Weighting weighting) {
-        this.weighting = weighting;
-    }
-
+    
     public void setDistanceCalc(DistanceCalc distanceCalc) {
         this.distanceCalc = distanceCalc;
     }
@@ -112,8 +111,12 @@ public class MapMatching {
         this.measurementErrorSigma = measurementErrorSigma;
     }
 
-    public void setMaxVisitedNodes(int maxNodesToVisit) {
-        this.maxVisitedNodes = maxNodesToVisit;
+    /**
+     * @deprecated use `match` instead.
+     */
+    @Deprecated
+    public MatchResult doWork(List<GPXEntry> gpxList) {
+    	return match(gpxList);
     }
 
     /**
@@ -122,7 +125,7 @@ public class MapMatching {
      * @param gpxList the input list with GPX points which should match to edges
      * of the graph specified in the constructor
      */
-    public MatchResult doWork(List<GPXEntry> gpxList) {
+    public MatchResult match(List<GPXEntry> gpxList) {
         if (gpxList.size() < 2) {
             throw new IllegalArgumentException("Too few coordinates in input file ("
                     + gpxList.size() + "). Correct format?");
@@ -136,7 +139,6 @@ public class MapMatching {
         final List<QueryResult> allCandidates = new ArrayList<>();
         List<TimeStep<GPXExtension, GPXEntry, Path>> timeSteps = createTimeSteps(gpxList,
                 edgeFilter, allCandidates);
-        // printMinDistances(timeSteps);
         
         if (allCandidates.size() < 2) {
             throw new IllegalArgumentException("Too few matching coordinates ("
@@ -233,7 +235,8 @@ public class MapMatching {
                 throw new RuntimeException("Sequence is broken for submitted track at time step "
                         + timeStepCounter + " (" + gpxList.size() + " points). " + likelyReasonStr
                         + "observation:" + timeStep.observation + ", candidates: "
-                        + getSnappedCandidates(timeStep.candidates));
+                        + getSnappedCandidates(timeStep.candidates) + ". If a match is expected "
+                        + "consider increasing maxVisitedNodes.");
             }
 
             timeStepCounter++;
@@ -265,11 +268,8 @@ public class MapMatching {
                 (timeStep.observation.getTime() - prevTimeStep.observation.getTime()) / 1000.0;
 
         for (GPXExtension from : prevTimeStep.candidates) {
-            for (GPXExtension to : timeStep.candidates) {
-                // TODO allow CH, then optionally use cached one-to-many Dijkstra to improve speed
-                final DijkstraBidirectionRef algo =
-                        new DijkstraBidirectionRef(queryGraph, encoder, weighting, traversalMode);
-                algo.setMaxVisitedNodes(maxVisitedNodes);
+        	for (GPXExtension to : timeStep.candidates) {
+                RoutingAlgorithm algo = algoFactory.createAlgo(queryGraph, algoOptions);
                 final Path path = algo.calcPath(from.getQueryResult().getClosestNode(),
                         to.getQueryResult().getClosestNode());
                 if (path.isFound()) {

--- a/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
@@ -63,34 +63,34 @@ public class MapMatching {
 
     private final Graph graph;
     private final LocationIndexMatch locationIndex;
-	private final FlagEncoder encoder;
+    private final FlagEncoder encoder;
     private double measurementErrorSigma = 50.0;
     private double transitionProbabilityBeta = 0.00959442;
     private final int nodeCount;
     private DistanceCalc distanceCalc = new DistancePlaneProjection();
-	private RoutingAlgorithmFactory algoFactory;
-	private AlgorithmOptions algoOptions;
-	private Weighting weighting;
-	
+    private RoutingAlgorithmFactory algoFactory;
+    private AlgorithmOptions algoOptions;
+    private Weighting weighting;
 
     public MapMatching(GraphHopper hopper, AlgorithmOptions algoOptions) {
-    	
-    	this.locationIndex = new LocationIndexMatch(hopper.getGraphHopperStorage(), (LocationIndexTree) hopper.getLocationIndex());
-    	this.encoder = algoOptions.getFlagEncoder();
-    	this.weighting = algoOptions.getWeighting();
-    	// get base graph, which differs depending on CH:
-    	this.graph = hopper.getGraphHopperStorage().getGraph((hopper.isCHEnabled() ? CHGraph.class : Graph.class), this.weighting);
-    	this.nodeCount = graph.getNodes();
+        this.locationIndex = new LocationIndexMatch(hopper.getGraphHopperStorage(),
+                (LocationIndexTree) hopper.getLocationIndex());
+        this.encoder = algoOptions.getFlagEncoder();
+        this.weighting = algoOptions.getWeighting();
+        // get base graph, which differs depending on CH:
+        this.graph = hopper.getGraphHopperStorage()
+                .getGraph((hopper.isCHEnabled() ? CHGraph.class : Graph.class), this.weighting);
+        this.nodeCount = graph.getNodes();
         this.algoOptions = algoOptions;
         // create hints from algoOptions, so we can create the algorithm factory
-    	PMap pmap = algoOptions.getHints();
-    	HintsMap hints = new HintsMap();    	
-    	for (String k: pmap.toMap().keySet()) {
-    		hints.put(k, pmap.get(k, null));
-    	}
-        this.algoFactory = hopper.getAlgorithmFactory(hints);   
+        PMap pmap = algoOptions.getHints();
+        HintsMap hints = new HintsMap();
+        for (String k : pmap.toMap().keySet()) {
+            hints.put(k, pmap.get(k, null));
+        }
+        this.algoFactory = hopper.getAlgorithmFactory(hints);
     }
-    
+
     public void setDistanceCalc(DistanceCalc distanceCalc) {
         this.distanceCalc = distanceCalc;
     }
@@ -112,20 +112,12 @@ public class MapMatching {
     }
 
     /**
-     * @deprecated use `match` instead.
-     */
-    @Deprecated
-    public MatchResult doWork(List<GPXEntry> gpxList) {
-    	return match(gpxList);
-    }
-
-    /**
      * This method does the actual map matching.
      * <p>
      * @param gpxList the input list with GPX points which should match to edges
      * of the graph specified in the constructor
      */
-    public MatchResult match(List<GPXEntry> gpxList) {
+    public MatchResult doWork(List<GPXEntry> gpxList) {
         if (gpxList.size() < 2) {
             throw new IllegalArgumentException("Too few coordinates in input file ("
                     + gpxList.size() + "). Correct format?");
@@ -268,15 +260,14 @@ public class MapMatching {
                 (timeStep.observation.getTime() - prevTimeStep.observation.getTime()) / 1000.0;
 
         for (GPXExtension from : prevTimeStep.candidates) {
-        	for (GPXExtension to : timeStep.candidates) {
+            for (GPXExtension to : timeStep.candidates) {
                 RoutingAlgorithm algo = algoFactory.createAlgo(queryGraph, algoOptions);
                 final Path path = algo.calcPath(from.getQueryResult().getClosestNode(),
                         to.getQueryResult().getClosestNode());
                 if (path.isFound()) {
                     timeStep.addRoadPath(from, to, path);
-                    final double transitionLogProbability =
-                            probabilities.transitionLogProbability(path.getDistance(),
-                            linearDistance, timeDiff);
+                    final double transitionLogProbability = probabilities
+                            .transitionLogProbability(path.getDistance(), linearDistance, timeDiff);
                     timeStep.addTransitionLogProbability(from, to, transitionLogProbability);
                 }
             }

--- a/matching-core/src/main/java/com/graphhopper/matching/MapMatchingMain.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/MapMatchingMain.java
@@ -86,7 +86,7 @@ public class MapMatchingMain {
             		algorithm(Parameters.Algorithms.DIJKSTRA_BI).traversalMode(hopper.getTraversalMode()).
                     flagEncoder(firstEncoder).weighting(new FastestWeighting(firstEncoder)).
                     maxVisitedNodes(args.getInt("max_visited_nodes", 1000)).
-                    hints(new HintsMap().put("weighting", "fastest").put("vehicle", "car")).
+                    hints(new HintsMap().put("weighting", "fastest").put("vehicle", firstEncoder.getClass().getName())).
                     build();
             MapMatching mapMatching = new MapMatching(hopper, opts);
             mapMatching.setTransitionProbabilityBeta(args.getDouble("transition_probability_beta", 0.00959442));
@@ -108,7 +108,7 @@ public class MapMatchingMain {
                     List<GPXEntry> inputGPXEntries = new GPXFile().doImport(gpxFile.getAbsolutePath()).getEntries();
                     importSW.stop();
                     matchSW.start();
-                    MatchResult mr = mapMatching.match(inputGPXEntries);
+                    MatchResult mr = mapMatching.doWork(inputGPXEntries);
                     matchSW.stop();
                     System.out.println(gpxFile);
                     System.out.println("\tmatches:\t" + mr.getEdgeMatches().size() + ", gps entries:" + inputGPXEntries.size());

--- a/matching-core/src/main/java/com/graphhopper/matching/MapMatchingMain.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/MapMatchingMain.java
@@ -20,10 +20,11 @@ package com.graphhopper.matching;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.PathWrapper;
 import com.graphhopper.reader.osm.GraphHopperOSM;
+import com.graphhopper.routing.AlgorithmOptions;
 import com.graphhopper.routing.Path;
 import com.graphhopper.routing.util.FlagEncoder;
-import com.graphhopper.storage.GraphHopperStorage;
-import com.graphhopper.storage.index.LocationIndexTree;
+import com.graphhopper.routing.util.HintsMap;
+import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.BBox;
 import java.io.File;
@@ -72,8 +73,7 @@ public class MapMatchingMain {
             logger.info("loading graph from cache");
             hopper.load("./graph-cache");
             FlagEncoder firstEncoder = hopper.getEncodingManager().fetchEdgeEncoders().get(0);
-            GraphHopperStorage graph = hopper.getGraphHopperStorage();
-
+            
             int gpsAccuracy = args.getInt("gps_accuracy", -1);
             if (gpsAccuracy < 0) {
                 // backward compatibility since 0.8
@@ -82,10 +82,13 @@ public class MapMatchingMain {
 
             String instructions = args.get("instructions", "");
             logger.info("Setup lookup index. Accuracy filter is at " + gpsAccuracy + "m");
-            LocationIndexMatch locationIndex = new LocationIndexMatch(graph,
-                    (LocationIndexTree) hopper.getLocationIndex());
-            MapMatching mapMatching = new MapMatching(graph, locationIndex, firstEncoder);
-            mapMatching.setMaxVisitedNodes(args.getInt("max_visited_nodes", 1000));
+            AlgorithmOptions opts = AlgorithmOptions.start().
+            		algorithm(Parameters.Algorithms.DIJKSTRA_BI).traversalMode(hopper.getTraversalMode()).
+                    flagEncoder(firstEncoder).weighting(new FastestWeighting(firstEncoder)).
+                    maxVisitedNodes(args.getInt("max_visited_nodes", 1000)).
+                    hints(new HintsMap().put("weighting", "fastest").put("vehicle", "car")).
+                    build();
+            MapMatching mapMatching = new MapMatching(hopper, opts);
             mapMatching.setTransitionProbabilityBeta(args.getDouble("transition_probability_beta", 0.00959442));
             mapMatching.setMeasurementErrorSigma(gpsAccuracy);
 
@@ -105,7 +108,7 @@ public class MapMatchingMain {
                     List<GPXEntry> inputGPXEntries = new GPXFile().doImport(gpxFile.getAbsolutePath()).getEntries();
                     importSW.stop();
                     matchSW.start();
-                    MatchResult mr = mapMatching.doWork(inputGPXEntries);
+                    MatchResult mr = mapMatching.match(inputGPXEntries);
                     matchSW.stop();
                     System.out.println(gpxFile);
                     System.out.println("\tmatches:\t" + mr.getEdgeMatches().size() + ", gps entries:" + inputGPXEntries.size());

--- a/matching-core/src/main/java/com/graphhopper/matching/MapMatchingMain.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/MapMatchingMain.java
@@ -86,7 +86,7 @@ public class MapMatchingMain {
             		algorithm(Parameters.Algorithms.DIJKSTRA_BI).traversalMode(hopper.getTraversalMode()).
                     flagEncoder(firstEncoder).weighting(new FastestWeighting(firstEncoder)).
                     maxVisitedNodes(args.getInt("max_visited_nodes", 1000)).
-                    hints(new HintsMap().put("weighting", "fastest").put("vehicle", firstEncoder.getClass().getName())).
+                    hints(new HintsMap().put("weighting", "fastest").put("vehicle", firstEncoder.toString())).
                     build();
             MapMatching mapMatching = new MapMatching(hopper, opts);
             mapMatching.setTransitionProbabilityBeta(args.getDouble("transition_probability_beta", 0.00959442));

--- a/matching-core/src/test/java/com/graphhopper/matching/MapMatchingTest.java
+++ b/matching-core/src/test/java/com/graphhopper/matching/MapMatchingTest.java
@@ -73,40 +73,40 @@ public class MapMatchingTest {
     }
 
     @Parameterized.Parameters(name="{0}")
-    public static Collection algoOptions() {
+    public static Collection<Object[]> algoOptions() {
 
         // CH:
-        CarFlagEncoder CHEncoder = new CarFlagEncoder();
-        TestGraphHopper CHHopper = new TestGraphHopper();
-        CHHopper.setDataReaderFile("../map-data/leipzig_germany.osm.pbf");
-        CHHopper.setGraphHopperLocation("../target/mapmatchingtest-ch");
-        CHHopper.setEncodingManager(new EncodingManager(CHEncoder));
-        CHHopper.getCHFactoryDecorator().setEnabled(true);
-        CHHopper.importOrLoad();
-        AlgorithmOptions CHOpts = AlgorithmOptions.start()
+        CarFlagEncoder chEncoder = new CarFlagEncoder();
+        TestGraphHopper chHopper = new TestGraphHopper();
+        chHopper.setDataReaderFile("../map-data/leipzig_germany.osm.pbf");
+        chHopper.setGraphHopperLocation("../target/mapmatchingtest-ch");
+        chHopper.setEncodingManager(new EncodingManager(chEncoder));
+        chHopper.getCHFactoryDecorator().setEnabled(true);
+        chHopper.importOrLoad();
+        AlgorithmOptions chOpts = AlgorithmOptions.start()
                 .algorithm(Parameters.Algorithms.DIJKSTRA_BI)
-                .traversalMode(CHHopper.getTraversalMode()).flagEncoder(CHEncoder)
-                .weighting(CHHopper.getCHFactoryDecorator().getWeightings().get(0))
+                .traversalMode(chHopper.getTraversalMode()).flagEncoder(chEncoder)
+                .weighting(chHopper.getCHFactoryDecorator().getWeightings().get(0))
                 .maxVisitedNodes(1000)
                 .hints(new HintsMap().put("weighting", "fastest").put("vehicle", "car")).build();
 
         // flexible:
-        CarFlagEncoder FlexibleEncoder = new CarFlagEncoder();
-        TestGraphHopper FlexibleHopper = new TestGraphHopper();
-        FlexibleHopper.setDataReaderFile("../map-data/leipzig_germany.osm.pbf");
-        FlexibleHopper.setGraphHopperLocation("../target/mapmatchingtest-flexible");
-        FlexibleHopper.setEncodingManager(new EncodingManager(FlexibleEncoder));
-        FlexibleHopper.getCHFactoryDecorator().setEnabled(false);
-        FlexibleHopper.importOrLoad();
-        AlgorithmOptions FlexibleOpts = AlgorithmOptions.start()
+        CarFlagEncoder flexibleEncoder = new CarFlagEncoder();
+        TestGraphHopper flexibleHopper = new TestGraphHopper();
+        flexibleHopper.setDataReaderFile("../map-data/leipzig_germany.osm.pbf");
+        flexibleHopper.setGraphHopperLocation("../target/mapmatchingtest-flexible");
+        flexibleHopper.setEncodingManager(new EncodingManager(flexibleEncoder));
+        flexibleHopper.getCHFactoryDecorator().setEnabled(false);
+        flexibleHopper.importOrLoad();
+        AlgorithmOptions flexibleOpts = AlgorithmOptions.start()
                 .algorithm(Parameters.Algorithms.DIJKSTRA_BI)
-                .traversalMode(FlexibleHopper.getTraversalMode()).flagEncoder(FlexibleEncoder)
-                .weighting(new FastestWeighting(FlexibleEncoder)).maxVisitedNodes(1000)
+                .traversalMode(flexibleHopper.getTraversalMode()).flagEncoder(flexibleEncoder)
+                .weighting(new FastestWeighting(flexibleEncoder)).maxVisitedNodes(1000)
                 .hints(new HintsMap().put("weighting", "fastest").put("vehicle", "car")).build();
 
         return Arrays.asList(new Object[][] {
-            { "CH", CHHopper, CHOpts },
-            { "non-CH", FlexibleHopper, FlexibleOpts } 
+            { "CH", chHopper, chOpts },
+            { "non-CH", flexibleHopper, flexibleOpts } 
             });
     }
 

--- a/matching-core/src/test/java/com/graphhopper/matching/MapMatchingTest.java
+++ b/matching-core/src/test/java/com/graphhopper/matching/MapMatchingTest.java
@@ -22,8 +22,12 @@ import com.graphhopper.GHResponse;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.PathWrapper;
 import com.graphhopper.reader.osm.GraphHopperOSM;
+import com.graphhopper.routing.AlgorithmOptions;
 import com.graphhopper.routing.Path;
 import com.graphhopper.routing.util.*;
+import com.graphhopper.routing.weighting.FastestWeighting;
+import com.graphhopper.storage.CHGraph;
+import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.storage.index.LocationIndex;
@@ -34,64 +38,100 @@ import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GPXEntry;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.InstructionList;
+import com.graphhopper.util.Parameters;
 import com.graphhopper.util.PathMerger;
 import com.graphhopper.util.Translation;
 import com.graphhopper.util.TranslationMap;
 import com.graphhopper.util.shapes.GHPoint;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+
 import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 /**
  *
  * @author Peter Karich
  */
+
+@RunWith(Parameterized.class)
 public class MapMatchingTest {
 
-    // disable turn restrictions in encoder:
-    private static final CarFlagEncoder ENCODER = new CarFlagEncoder();
-    private static final TestGraphHopper HOPPER = new TestGraphHopper();
     public final static TranslationMap SINGLETON = new TranslationMap().doImport();
+    
+    // parameterize:
+    private TestGraphHopper hopper;
+    private AlgorithmOptions algoOption; 
+    public MapMatchingTest(TestGraphHopper hopper, AlgorithmOptions algoOption) {
+    	this.algoOption = algoOption;
+    	this.hopper = hopper;
+    }
+    
+    @Parameterized.Parameters
+    public static Collection algoOptions() {
 
-    @BeforeClass
-    public static void doImport() {
-        HOPPER.setDataReaderFile("../map-data/leipzig_germany.osm.pbf");
-        HOPPER.setGraphHopperLocation("../target/mapmatchingtest");
-        HOPPER.setEncodingManager(new EncodingManager(ENCODER));
-        HOPPER.getCHFactoryDecorator().setEnabled(false);
-        // hopper.clean();
-        HOPPER.importOrLoad();
+        // CH:
+    	CarFlagEncoder CHEncoder = new CarFlagEncoder();
+    	TestGraphHopper CHHopper = new TestGraphHopper();
+    	CHHopper.setDataReaderFile("../map-data/leipzig_germany.osm.pbf");
+    	CHHopper.setGraphHopperLocation("../target/mapmatchingtest-ch");
+    	CHHopper.setEncodingManager(new EncodingManager(CHEncoder));
+    	CHHopper.getCHFactoryDecorator().setEnabled(true);
+    	CHHopper.importOrLoad();
+    	AlgorithmOptions CHOpts = AlgorithmOptions.start().
+    		algorithm(Parameters.Algorithms.DIJKSTRA_BI).traversalMode(CHHopper.getTraversalMode()).
+            flagEncoder(CHEncoder).weighting(new FastestWeighting(CHEncoder)).
+            maxVisitedNodes(1000).
+            hints(new HintsMap().put("weighting", "fastest").put("vehicle", "car")).
+            build();
+        
+        // flexible:
+    	CarFlagEncoder FlexibleEncoder = new CarFlagEncoder();
+    	TestGraphHopper FlexibleHopper = new TestGraphHopper();
+    	FlexibleHopper.setDataReaderFile("../map-data/leipzig_germany.osm.pbf");
+    	FlexibleHopper.setGraphHopperLocation("../target/mapmatchingtest-flexible");
+    	FlexibleHopper.setEncodingManager(new EncodingManager(FlexibleEncoder));
+    	FlexibleHopper.getCHFactoryDecorator().setEnabled(false);
+    	FlexibleHopper.importOrLoad();
+    	AlgorithmOptions FlexibleOpts = AlgorithmOptions.start().
+    		algorithm(Parameters.Algorithms.DIJKSTRA_BI).traversalMode(FlexibleHopper.getTraversalMode()).
+            flagEncoder(FlexibleEncoder).weighting(new FastestWeighting(FlexibleEncoder)).
+            maxVisitedNodes(1000).
+            hints(new HintsMap().put("weighting", "fastest").put("vehicle", "car")).
+            build();
+
+     	return Arrays.asList(new Object[][] {
+     		{CHHopper, CHOpts},
+     		{FlexibleHopper, FlexibleOpts} 		
+     	});
     }
 
-    @AfterClass
-    public static void doClose() {
-        HOPPER.close();
-    }
 
+    /**
+     * TODO: split this test up into smaller units with better names?
+     */
     @Test
     public void testDoWork() {
-        GraphHopperStorage graph = HOPPER.getGraphHopperStorage();
-        LocationIndexMatch locationIndex = new LocationIndexMatch(graph,
-                (LocationIndexTree) HOPPER.getLocationIndex());
-
-        MapMatching mapMatching = new MapMatching(graph, locationIndex, ENCODER);
-        // mapMatching.setMeasurementErrorSigma(5);
-
-        // printOverview(graph, hopper.getLocationIndex(), 51.358735, 12.360574, 500);
+    	        
+        MapMatching mapMatching = new MapMatching(hopper, algoOption);
         List<GPXEntry> inputGPXEntries = createRandomGPXEntries(
                 new GHPoint(51.358735, 12.360574),
                 new GHPoint(51.358594, 12.360032));
-
-        MatchResult mr = mapMatching.doWork(inputGPXEntries);
+        MatchResult mr = mapMatching.match(inputGPXEntries);
 
         // make sure no virtual edges are returned
-        int edgeCount = graph.getAllEdges().getMaxId();
+        int edgeCount = hopper.getGraphHopperStorage().getAllEdges().getMaxId();
         for (EdgeMatch em : mr.getEdgeMatches()) {
             assertTrue("result contains virtual edges:" + em.getEdgeState().toString(), em.getEdgeState().getEdge() < edgeCount);
         }
@@ -113,7 +153,7 @@ public class MapMatchingTest {
         inputGPXEntries = createRandomGPXEntries(
                 new GHPoint(51.33099, 12.380267),
                 new GHPoint(51.330689, 12.380776));
-        mr = mapMatching.doWork(inputGPXEntries);
+        mr = mapMatching.match(inputGPXEntries);
 
         assertEquals(Arrays.asList("Windmühlenstraße", "Windmühlenstraße",
                 "Bayrischer Platz", "Bayrischer Platz", "Bayrischer Platz"),
@@ -134,13 +174,10 @@ public class MapMatchingTest {
         inputGPXEntries = createRandomGPXEntries(
                 new GHPoint(51.377781, 12.338333),
                 new GHPoint(51.323317, 12.387085));
-        mapMatching = new MapMatching(graph, locationIndex, ENCODER);
+        mapMatching = new MapMatching(hopper, algoOption);
         mapMatching.setMeasurementErrorSigma(20);
-        // new GPXFile(inputGPXEntries).doExport("test-input.gpx");
-        mr = mapMatching.doWork(inputGPXEntries);
-        // new GPXFile(mr).doExport("test.gpx");
+        mr = mapMatching.match(inputGPXEntries);
 
-        // System.out.println(fetchStreets(mr.getEdgeMatches()));
         assertEquals(mr.getGpxEntriesLength(), mr.getMatchLength(), 0.5);
         assertEquals(mr.getGpxEntriesMillis(), mr.getMatchMillis(), 200);
         assertEquals(138, mr.getEdgeMatches().size());
@@ -149,19 +186,50 @@ public class MapMatchingTest {
         // TODO full path with 40m distortion
     }
 
+    /**
+     * This test is to check behavior over large separated routes: it should work if the 
+     * user sets the maxVisitedNodes large enough. Input path:
+     * https://graphhopper.com/maps/?point=51.23%2C12.18&point=51.45%2C12.59&layer=Lyrk
+     */
+    @Test
+    public void testDistantPoints() {
+    	
+        // OK with 1000 visited nodes:
+        MapMatching mapMatching = new MapMatching(hopper, algoOption);
+        List<GPXEntry> inputGPXEntries = createRandomGPXEntries(
+                new GHPoint(51.23, 12.18),
+                new GHPoint(51.45, 12.59));
+        MatchResult mr = mapMatching.match(inputGPXEntries);
+        assertEquals(mr.getMatchLength(), 57653, 1);
+        assertEquals(mr.getMatchMillis(), 2748186, 1);
+        
+        // not OK when we only allow a small number of visited nodes:
+        FlagEncoder car = hopper.getEncodingManager().getEncoder("car");
+        AlgorithmOptions opts = AlgorithmOptions.start().
+        		algorithm(Parameters.Algorithms.DIJKSTRA_BI).traversalMode(hopper.getTraversalMode()).
+                flagEncoder(car).weighting(new FastestWeighting(car)).maxVisitedNodes(1).
+                hints(new HintsMap().put("weighting", "fastest").put("vehicle", "car")).
+                build();
+        mapMatching = new MapMatching(hopper, opts);
+        try {
+        	mr = mapMatching.match(inputGPXEntries);
+        	fail("Expected sequence to be broken due to maxVisitedNodes being too small");
+        } catch (RuntimeException e) {
+        	assertTrue(e.getMessage().startsWith("Sequence is broken for submitted track"));
+        }
+    }
+    
+    /**
+     * This test is to check what happens when two GPX entries are on one edge which is longer than
+     * 'separatedSearchDistance' - which is always 66m. GPX input:
+     * https://graphhopper.com/maps/?point=51.359723%2C12.360108&point=51.358748%2C12.358798&point=51.358001%2C12.357597&point=51.358709%2C12.356511&layer=Lyrk
+     */
     @Test
     public void testSmallSeparatedSearchDistance() {
-        GraphHopperStorage graph = HOPPER.getGraphHopperStorage();
-        LocationIndexMatch locationIndex = new LocationIndexMatch(graph,
-                (LocationIndexTree) HOPPER.getLocationIndex());
-
-        // import sample where two GPX entries are on one edge which is longer than 'separatedSearchDistance' aways (66m)
-        // https://graphhopper.com/maps/?point=51.359723%2C12.360108&point=51.358748%2C12.358798&point=51.358001%2C12.357597&point=51.358709%2C12.356511&layer=Lyrk
         List<GPXEntry> inputGPXEntries = new GPXFile().doImport("./src/test/resources/tour3-with-long-edge.gpx").getEntries();
-        // TODO match at Weinlingstraße instead of following small part of Marbachstraße
-        MapMatching mapMatching = new MapMatching(graph, locationIndex, ENCODER);
+        MapMatching mapMatching = new MapMatching(hopper, algoOption);
         mapMatching.setMeasurementErrorSigma(20);
-        MatchResult mr = mapMatching.doWork(inputGPXEntries);
+        MatchResult mr = mapMatching.match(inputGPXEntries);
         assertEquals(Arrays.asList("Weinligstraße", "Weinligstraße",
                 "Weinligstraße", "Fechnerstraße", "Fechnerstraße"),
                 fetchStreets(mr.getEdgeMatches()));
@@ -169,20 +237,15 @@ public class MapMatchingTest {
         assertEquals(mr.getGpxEntriesMillis(), mr.getMatchMillis(), 3000);
     }
 
+    /**
+     * This test is to check that loops are maintained. GPX input:
+     * https://graphhopper.com/maps/?point=51.343657%2C12.360708&point=51.344982%2C12.364066&point=51.344841%2C12.361223&point=51.342781%2C12.361867&layer=Lyrk
+     */
     @Test
     public void testLoop() {
-        GraphHopperStorage graph = HOPPER.getGraphHopperStorage();
-        LocationIndexMatch locationIndex = new LocationIndexMatch(graph,
-                (LocationIndexTree) HOPPER.getLocationIndex());
-        MapMatching mapMatching = new MapMatching(graph, locationIndex, ENCODER);
-
-        // printOverview(graph, hopper.getLocationIndex(), 51.345796,12.360681, 1000);
-        // https://graphhopper.com/maps/?point=51.343657%2C12.360708&point=51.344982%2C12.364066&point=51.344841%2C12.361223&point=51.342781%2C12.361867&layer=Lyrk
+        MapMatching mapMatching = new MapMatching(hopper, algoOption);
         List<GPXEntry> inputGPXEntries = new GPXFile().doImport("./src/test/resources/tour2-with-loop.gpx").getEntries();
-        MatchResult mr = mapMatching.doWork(inputGPXEntries);
-        // new GPXFile(mr).doExport("testLoop-matched.gpx");
-
-        // Expected is ~800m. If too short like 166m then the loop was skipped        
+        MatchResult mr = mapMatching.match(inputGPXEntries);        
         assertEquals(Arrays.asList("Gustav-Adolf-Straße", "Gustav-Adolf-Straße",
                 "Gustav-Adolf-Straße", "Leibnizstraße", "Hinrichsenstraße",
                 "Hinrichsenstraße", "Tschaikowskistraße", "Tschaikowskistraße"),
@@ -192,42 +255,45 @@ public class MapMatchingTest {
         assertEquals(mr.getGpxEntriesMillis(), mr.getMatchMillis(), 6000);
     }
 
+    /**
+     * This test is to check that loops are maintained. GPX input:
+     * https://graphhopper.com/maps/?point=51.342439%2C12.361615&point=51.343719%2C12.362784&point=51.343933%2C12.361781&point=51.342325%2C12.362607&layer=Lyrk
+     */
     @Test
     public void testLoop2() {
-        GraphHopperStorage graph = HOPPER.getGraphHopperStorage();
-        LocationIndexMatch locationIndex = new LocationIndexMatch(graph,
-                (LocationIndexTree) HOPPER.getLocationIndex());
-        MapMatching mapMatching = new MapMatching(graph, locationIndex, ENCODER);
+        MapMatching mapMatching = new MapMatching(hopper, algoOption);
         // TODO smaller sigma like 40m leads to U-turn at Tschaikowskistraße
         mapMatching.setMeasurementErrorSigma(50);
-        // https://graphhopper.com/maps/?point=51.342439%2C12.361615&point=51.343719%2C12.362784&point=51.343933%2C12.361781&point=51.342325%2C12.362607&layer=Lyrk
         List<GPXEntry> inputGPXEntries = new GPXFile().doImport("./src/test/resources/tour-with-loop.gpx").getEntries();
-        MatchResult mr = mapMatching.doWork(inputGPXEntries);
+        MatchResult mr = mapMatching.match(inputGPXEntries);
         assertEquals(Arrays.asList("Jahnallee, B 87, B 181", "Jahnallee, B 87, B 181",
                 "Jahnallee, B 87, B 181", "Jahnallee, B 87, B 181", "Funkenburgstraße",
                 "Gustav-Adolf-Straße", "Tschaikowskistraße", "Jahnallee, B 87, B 181",
                 "Lessingstraße", "Lessingstraße"),
                 fetchStreets(mr.getEdgeMatches()));
     }
-
+    
+    /**
+     * This test is to check that U-turns are avoided when it's just measurement
+     * error, though do occur when a point goes up a road further than the measurement
+     * error. GPX input:
+     * https://graphhopper.com/maps/?point=51.343618%2C12.360772&point=51.34401%2C12.361776&point=51.343977%2C12.362886&point=51.344734%2C12.36236&point=51.345233%2C12.362055&layer=Lyrk
+     */
     @Test
     public void testUTurns() {
-        GraphHopperStorage graph = HOPPER.getGraphHopperStorage();
-        LocationIndexMatch locationIndex = new LocationIndexMatch(graph,
-                (LocationIndexTree) HOPPER.getLocationIndex());
-        MapMatching mapMatching = new MapMatching(graph, locationIndex, ENCODER);
-
-        // https://graphhopper.com/maps/?point=51.343618%2C12.360772&point=51.34401%2C12.361776&point=51.343977%2C12.362886&point=51.344734%2C12.36236&point=51.345233%2C12.362055&layer=Lyrk
+        MapMatching mapMatching = new MapMatching(hopper, algoOption);
         List<GPXEntry> inputGPXEntries = new GPXFile().doImport("./src/test/resources/tour4-with-uturn.gpx").getEntries();
+        
+        // with large measurement error, we expect no U-turn
         mapMatching.setMeasurementErrorSigma(50);
-        MatchResult mr = mapMatching.doWork(inputGPXEntries);
+        MatchResult mr = mapMatching.match(inputGPXEntries);
         assertEquals(Arrays.asList("Gustav-Adolf-Straße", "Gustav-Adolf-Straße",
                 "Funkenburgstraße", "Funkenburgstraße"),
                 fetchStreets(mr.getEdgeMatches()));
 
-        // inclusive U-turn
+        // with small measurement error, we expect the U-turn
         mapMatching.setMeasurementErrorSigma(10);
-        mr = mapMatching.doWork(inputGPXEntries);
+        mr = mapMatching.match(inputGPXEntries);
         assertEquals(Arrays.asList("Gustav-Adolf-Straße", "Gustav-Adolf-Straße",
                 "Funkenburgstraße", "Funkenburgstraße", "Funkenburgstraße", "Funkenburgstraße"),
                 fetchStreets(mr.getEdgeMatches()));
@@ -255,8 +321,8 @@ public class MapMatchingTest {
     }
 
     private List<GPXEntry> createRandomGPXEntries(GHPoint start, GHPoint end) {
-        HOPPER.route(new GHRequest(start, end).setWeighting("fastest"));
-        return HOPPER.getEdges(0);
+    	hopper.route(new GHRequest(start, end).setWeighting("fastest"));
+        return hopper.getEdges(0);
     }
 
     private void printOverview(GraphHopperStorage graph, LocationIndex locationIndex,
@@ -287,7 +353,7 @@ public class MapMatchingTest {
         }.start(explorer, node);
     }
 
-    // use a workaround to get access to 
+    // use a workaround to get access to paths
     static class TestGraphHopper extends GraphHopperOSM {
 
         private List<Path> paths;
@@ -296,7 +362,6 @@ public class MapMatchingTest {
             Path path = paths.get(index);
             Translation tr = getTranslationMap().get("en");
             InstructionList instr = path.calcInstructions(tr);
-            // GPXFile.write(path, "calculated-route.gpx", tr);
             return instr.createGPXList();
         }
 

--- a/matching-web/src/main/java/com/graphhopper/matching/http/MatchServlet.java
+++ b/matching-web/src/main/java/com/graphhopper/matching/http/MatchServlet.java
@@ -107,6 +107,7 @@ public class MatchServlet extends GraphHopperServlet {
         boolean enableTraversalKeys = getBooleanParam(httpReq, "traversal_keys", false);
 
         String vehicle = getParam(httpReq, "vehicle", "car");
+        String weighting = getParam(httpReq, "weighting", "fastest");
         int maxVisitedNodes = Math.min(getIntParam(httpReq, "max_visited_nodes", 3000), 5000);
         double defaultAccuracy = 40;
         double gpsAccuracy = Math.min(Math.max(getDoubleParam(httpReq, "gps_accuracy", defaultAccuracy), 5), gpsMaxAccuracy);
@@ -120,9 +121,8 @@ public class MatchServlet extends GraphHopperServlet {
                 AlgorithmOptions opts = AlgorithmOptions.start()
                         .algorithm(Parameters.Algorithms.DIJKSTRA_BI)
                         .traversalMode(hopper.getTraversalMode()).flagEncoder(encoder)
-                        .weighting(new FastestWeighting(encoder))
                         .maxVisitedNodes(maxVisitedNodes).hints(new HintsMap()
-                                .put("weighting", "fastest").put("vehicle", encoder.toString()))
+                                .put("weighting", weighting).put("vehicle", encoder.toString()))
                         .build();
                 MapMatching matching = new MapMatching(hopper, opts);
                 matching.setMeasurementErrorSigma(gpsAccuracy);


### PR DESCRIPTION
Based on #60, though supports all (?) algorithms, not just CH.

#### GH change required

Not sure if it's a bug, but I had to change [this](https://github.com/graphhopper/graphhopper/blob/master/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java#L105):

    if (cg.getWeighting() == weighting)

to

    if (cg.getWeighting().getName() == weighting.getName())

#### Changed API

That is

    new MapMatching(graph, locationIndex, encoder)

becomes

    new MapMatching(hopper, algorithmOptions)

Easiest to see in the unit tests. Why did I change it?

- it seems cleaner
  - as a user, all I need to provide is a GH instance, plus information about which algorithm to use, etc. No need to provide e.g. a `LocationIndexMatch` (which generally I have no need for) etc.
 - it also unifies e.g. there's no need to separately set `maxVisitedNodes` as this is part of `algorithmOptions`.
- flexibility: the user can specify any algorithm options, including CH.
- GH already supports varying algorithms with the `algorithmOptions`. All the other approaches I tried were messier and involved changing the GH core too much.

Considerations (@karussell):

- we could make it even easier by creasing `new MapMatching(hopper)` which makes some sensible assumptions about the algorithm to use. The intent being to make it as easy as possible for users.
- it could probably do with some better sense checking - I'm not sure, but I imagine it's possible to provide `algorithmOptions` that won't work with the provided `hopper`.
- also changed `doWork` to `match`, again as it seems to make sense for the user
- it might be possible to maintain support for the old API - do you think it's worth it?

#### CH support

Seems to work fine, and I've parameterised some of the unit tests to run with both a CH and non-CH algorithm - both are passing fine. I'm still working on the Measurement option, but it's safe to say CH can be a fair bit faster.
