### PR TITLE
Dedupe query results

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,7 +5,7 @@
  * michaz, very important hidden markov improvement via hmm-lib, see #49
  * rory, support milisecond gpx timestamps, see #4 
  * stefanholder, Stefan Holder, BMW AG, creating and integrating the hmm-lib (#49, #66, #69) and
- penalizing inner-link U-turns (#70)
- * kodonnell, adding support for CH and other algorithms (#60) and penalizing inner-link U-turns (#70)
+ penalizing inner-link U-turns (#88, #91)
+ * kodonnell, adding support for CH and other algorithms (#60) and penalizing inner-link U-turns (#88)
 
 For GraphHopper contributors see [here](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTORS.md).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ gps_accuracy=15              # default=15, type=int, unit=meter, the precision o
 
 This will produce gpx results similar named as the input files.
 
+Developer note: After changing the code you should run `mvn clean` before running `map-matching.sh`
+again.
+
 ### UI and matching Service
 
 Start via:
@@ -122,4 +125,20 @@ like when updating the OSM data.
 
 ### About
 
-See [this project](https://github.com/bmwcarit/hmm-lib) from [Stefan](https://github.com/stefanholder) which is used in combination with the GraphHopper routing engine and is used as the algorithmic approach now. Before it was [this faster but more heuristic approach](https://karussell.wordpress.com/2014/07/28/digitalizing-gpx-points-or-how-to-track-vehicles-with-graphhopper/).
+The map matching algorithm mainly follows the approach described in
+
+*Newson, Paul, and John Krumm. "Hidden Markov map matching through noise and sparseness."
+Proceedings of the 17th ACM SIGSPATIAL International Conference on Advances in Geographic
+Information Systems. ACM, 2009.*
+
+This algorithm works as follows. For each input GPS position, a number of
+map matching candidates within a certain radius around the GPS position is computed.
+The [Viterbi algorithm](https://en.wikipedia.org/wiki/Viterbi_algorithm) as provided by the
+[hmm-lib](https://github.com/bmwcarit/hmm-lib) is then used to compute the most likely sequence
+of map matching candidates. Thereby, the distances between GPS positions and map matching
+candidates as well as the routing distances between consecutive map matching candidates are taken
+into account. The GraphHopper routing engine is used to find candidates and to compute routing
+distances.
+
+Before GraphHopper 0.8, [this faster but more heuristic approach](https://karussell.wordpress.com/2014/07/28/digitalizing-gpx-points-or-how-to-track-vehicles-with-graphhopper/)
+was used.

--- a/matching-core/src/main/java/com/graphhopper/matching/LocationIndexMatch.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/LocationIndexMatch.java
@@ -52,16 +52,24 @@ public class LocationIndexMatch extends LocationIndexTree {
         this.index = index;
     }
 
-    public List<QueryResult> findNClosest(final double queryLat, final double queryLon, final EdgeFilter edgeFilter,
-                                          double gpxAccuracyInMetern) {
+    /**
+     * Returns all edges that are within the specified radius around the queried position.
+     * Searches at most 9 cells to avoid performance problems. Hence, if the radius is larger than
+     * the cell width then not all edges might be returned.
+     *
+     * @param radius in meters
+     */
+    public List<QueryResult> findNClosest(final double queryLat, final double queryLon,
+            final EdgeFilter edgeFilter, double radius) {
         // Return ALL results which are very close and e.g. within the GPS signal accuracy.
         // Also important to get all edges if GPS point is close to a junction.
-        final double returnAllResultsWithin = distCalc.calcNormalizedDist(gpxAccuracyInMetern);
+        final double returnAllResultsWithin = distCalc.calcNormalizedDist(radius);
 
         // implement a cheap priority queue via List, sublist and Collections.sort
         final List<QueryResult> queryResults = new ArrayList<QueryResult>();
         GHIntHashSet set = new GHIntHashSet();
 
+        // Doing 2 iterations means searching 9 tiles.
         for (int iteration = 0; iteration < 2; iteration++) {
             // should we use the return value of earlyFinish?
             index.findNetworkEntries(queryLat, queryLon, set, iteration);

--- a/matching-core/src/main/java/com/graphhopper/matching/MapMatchingMain.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/MapMatchingMain.java
@@ -86,6 +86,8 @@ public class MapMatchingMain {
                     algorithm(Parameters.Algorithms.DIJKSTRA_BI).traversalMode(hopper.getTraversalMode()).
                     weighting(new FastestWeighting(firstEncoder)).
                     maxVisitedNodes(args.getInt("max_visited_nodes", 1000)).
+                    // Penalizing inner-link U-turns only works with fastest weighting, since
+                    // shortest weighting does not apply penalties to unfavored virtual edges.
                     hints(new HintsMap().put("weighting", "fastest").put("vehicle", firstEncoder.toString())).
                     build();
             MapMatching mapMatching = new MapMatching(hopper, opts);


### PR DESCRIPTION
Dedupes the QueryResults of each GPX entry by node id after calling `QueryGraph.lookup` as discussed in #81. This only dedupes tower nodes but not virtual nodes since there is at most one QueryResult per edge and virtual nodes are inserted into the middle of an edge.

Reducing the number of QueryResults improves performance since less shortest/fastest routes need to be computed.

Also updated README.md.