### PR TITLE
Throw an exception if the input GPX file doesn't contain trackpoints

### DIFF
--- a/matching-core/src/main/java/com/graphhopper/matching/GPXFile.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/GPXFile.java
@@ -152,6 +152,9 @@ public class GPXFile {
                 prevLon = lon;
                 prevMillis = millis;
             }
+            if (entries.size() == 0) {
+                throw new ParseException("No trackpoints found in GPX file", 0);
+            }
             return this;
         } catch (ParseException e) {
             throw new RuntimeException(e);

--- a/matching-core/src/test/java/com/graphhopper/matching/GPXFileTest.java
+++ b/matching-core/src/test/java/com/graphhopper/matching/GPXFileTest.java
@@ -21,7 +21,11 @@ import com.graphhopper.util.GPXEntry;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.List;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import static org.junit.Assert.*;
 
 /**
@@ -29,6 +33,9 @@ import static org.junit.Assert.*;
  * @author Peter Karich
  */
 public class GPXFileTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testDoImport() {
@@ -64,5 +71,13 @@ public class GPXFileTest {
     public void testParseDate() throws ParseException {
         SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
         assertEquals(1412700604000L, df.parse("2014-10-07T16:50:04+0000").getTime());
+    }
+
+    @Test
+    public void testGPXWithoutTrackpoints() throws RuntimeException {
+        GPXFile instance = new GPXFile();
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("java.text.ParseException: No trackpoints found in GPX file");
+        instance.doImport("./src/test/resources/test-only-wpt.gpx");
     }
 }

--- a/matching-core/src/test/resources/test-only-wpt.gpx
+++ b/matching-core/src/test/resources/test-only-wpt.gpx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?><gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" creator="Graphhopper" version="1.1" xmlns:gh="https://graphhopper.com/public/schema/gpx/1.1">
+<metadata><copyright author="OpenStreetMap contributors"/><link href="http://graphhopper.com"><text>GraphHopper GPX</text></link><time>1970-01-01T00:00:00+00:00</time></metadata>
+<rte>
+<rtept lat="51.377719" lon="12.338217"><desc>continue onto Fučikstraße</desc><extensions><gh:distance>101.0</gh:distance><gh:time>14545</gh:time><gh:direction>SE</gh:direction><gh:azimuth>126</gh:azimuth></extensions></rtept>
+<rtept lat="51.37703" lon="12.339166"><desc>turn left onto Chamissoweg</desc><extensions><gh:distance>86.7</gh:distance><gh:time>20814</gh:time><gh:direction>NE</gh:direction><gh:azimuth>61</gh:azimuth></extensions></rtept>
+<rtept lat="51.37754" lon="12.340111"><desc>turn right onto Swiftstraße</desc><extensions><gh:distance>201.1</gh:distance><gh:time>28963</gh:time><gh:direction>SE</gh:direction><gh:azimuth>127</gh:azimuth></extensions></rtept>
+<rtept lat="51.376151" lon="12.34196"><desc>turn left onto Defoestraße</desc><extensions><gh:distance>179.6</gh:distance><gh:time>25866</gh:time><gh:direction>E</gh:direction><gh:azimuth>84</gh:azimuth></extensions></rtept>
+<rtept lat="51.375622" lon="12.343643"><extensions><gh:distance>54.5</gh:distance><gh:time>7840</gh:time><gh:direction>SE</gh:direction><gh:azimuth>134</gh:azimuth></extensions></rtept>
+</rte>
+<wpt lat="51.377719" lon="12.338217"><time>1970-01-01T00:00:00+00:00</time></wpt>
+<wpt lat="51.37703" lon="12.339166"><time>1970-01-01T00:00:14+00:00</time></wpt>
+<wpt lat="51.37754" lon="12.340111"><time>1970-01-01T00:00:35+00:00</time></wpt>
+<wpt lat="51.376201" lon="12.341925"><time>1970-01-01T00:01:03+00:00</time></wpt>
+<wpt lat="51.376151" lon="12.34196"><time>1970-01-01T00:01:04+00:00</time></wpt>
+<wpt lat="51.376307" lon="12.343399"><time>1970-01-01T00:01:18+00:00</time></wpt>
+<wpt lat="51.37578" lon="12.343556"><time>1970-01-01T00:01:27+00:00</time></wpt>
+<wpt lat="51.375622" lon="12.343643"><time>1970-01-01T00:01:30+00:00</time></wpt>
+</gpx>

--- a/matching-web/src/test/java/com/graphhopper/matching/http/MapMatchingResourceTest.java
+++ b/matching-web/src/test/java/com/graphhopper/matching/http/MapMatchingResourceTest.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.InputStream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Peter Karich
@@ -78,9 +79,10 @@ public class MapMatchingResourceTest {
     public void testEmptyGPX() {
         String emptyGPX = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?><gpx xmlns=\"http://www.topografix.com/GPX/1/1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" creator=\"Graphhopper\" version=\"1.1\" xmlns:gh=\"https://graphhopper.com/public/schema/gpx/1.1\"></gpx>";
         final Response response = app.client().target("http://localhost:8080/match").request().buildPost(Entity.xml(emptyGPX)).invoke();
-        assertEquals(200, response.getStatus());
+        assertEquals(500, response.getStatus());
         JsonNode json = response.readEntity(JsonNode.class);
-        JsonNode path = json.get("paths").get(0);
-        assertEquals(0, WebHelper.decodePolyline(path.get("points").asText(), 10, false).size());
+        JsonNode message = json.get("message");
+        assertTrue(message.isValueNode());
+        assertTrue(message.asText().startsWith("There was an error processing your request."));
     }
 }


### PR DESCRIPTION
Otherwise the result returned by the map matching API would be an GPX
file without any trackpoints.

Without this patch:

```
michael@hatano:~/git/github.com/graphhopper/map-matching$ curl -XPOST -H "Content-Type: application/gpx+xml" -d @matching-core/src/test/resources/test-only-wpt.gpx "localhost:8989/match?vehicle=car&type=gpx"
<?xml version="1.0" encoding="UTF-8" standalone="no" ?><gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" creator="Graphhopper version 0.11.0" version="1.1" xmlns:gh="https://graphhopper.com/public/schema/gpx/1.1">
<metadata><copyright author="OpenStreetMap contributors"/><link href="http://graphhopper.com"><text>GraphHopper GPX</text></link><time>2018-06-14T11:34:16Z</time></metadata>
<trk><name>GraphHopper Track</name><trkseg>
</trkseg>
</trk>
</gpx>
```

With this patch, an error message will be returned (the wrong format is a different issue and will be fixed by https://github.com/graphhopper/graphhopper/pull/1390

```
curl -XPOST -H "Content-Type: application/gpx+xml" -d @matching-core/src/test/resources/test-only-wpt.gpx  "localhost:8989/match?vehicle=car&type=gpx"
{"code":500,"message":"There was an error processing your request. It has been logged (ID 7fb0f76e14f13322)."}
```

Returning an empty GPX response is confusing.