### PR TITLE
Code refactoring

### DIFF
--- a/hmm-lib/src/main/java/com/bmw/hmm/ViterbiAlgorithm.java
+++ b/hmm-lib/src/main/java/com/bmw/hmm/ViterbiAlgorithm.java
@@ -281,10 +281,10 @@ public class ViterbiAlgorithm<S, O, D> {
         sb.append("Message history with log probabilies\n\n");
         int i = 0;
         for (Map<S, Double> message : messageHistory) {
-            sb.append("Time step " + i + "\n");
+            sb.append("Time step ").append(i).append("\n");
             i++;
             for (S state : message.keySet()) {
-                sb.append(state + ": " + message.get(state) + "\n");
+                sb.append(state).append(": ").append(message.get(state)).append("\n");
             }
             sb.append("\n");
         }
@@ -387,7 +387,7 @@ public class ViterbiAlgorithm<S, O, D> {
     private double transitionLogProbability(S prevState, S curState, Map<Transition<S>,
             Double> transitionLogProbabilities) {
         final Double transitionLogProbability =
-                transitionLogProbabilities.get(new Transition<S>(prevState, curState));
+                transitionLogProbabilities.get(new Transition<>(prevState, curState));
         if (transitionLogProbability == null) {
             return Double.NEGATIVE_INFINITY; // Transition has zero probability.
         } else {

--- a/hmm-lib/src/test/java/com/bmw/hmm/ViterbiAlgorithmTest.java
+++ b/hmm-lib/src/test/java/com/bmw/hmm/ViterbiAlgorithmTest.java
@@ -20,19 +20,17 @@ package com.bmw.hmm;
 import static java.lang.Math.log;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-
-import com.bmw.hmm.SequenceState;
-import com.bmw.hmm.Transition;
-import com.bmw.hmm.ViterbiAlgorithm;
 
 public class ViterbiAlgorithmTest {
 
@@ -118,16 +116,16 @@ public class ViterbiAlgorithmTest {
         emissionLogProbabilitiesForNoUmbrella.put(Rain.F, log(0.8));
 
         final Map<Transition<Rain>, Double> transitionLogProbabilities = new LinkedHashMap<>();
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.T, Rain.T), log(0.7));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.T, Rain.F), log(0.3));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.F, Rain.T), log(0.3));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.F, Rain.F), log(0.7));
+        transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.T), log(0.7));
+        transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.F), log(0.3));
+        transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.T), log(0.3));
+        transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.F), log(0.7));
 
         final Map<Transition<Rain>, Descriptor> transitionDescriptors = new LinkedHashMap<>();
-        transitionDescriptors.put(new Transition<Rain>(Rain.T, Rain.T), Descriptor.R2R);
-        transitionDescriptors.put(new Transition<Rain>(Rain.T, Rain.F), Descriptor.R2S);
-        transitionDescriptors.put(new Transition<Rain>(Rain.F, Rain.T), Descriptor.S2R);
-        transitionDescriptors.put(new Transition<Rain>(Rain.F, Rain.F), Descriptor.S2S);
+        transitionDescriptors.put(new Transition<>(Rain.T, Rain.T), Descriptor.R2R);
+        transitionDescriptors.put(new Transition<>(Rain.T, Rain.F), Descriptor.R2S);
+        transitionDescriptors.put(new Transition<>(Rain.F, Rain.T), Descriptor.S2R);
+        transitionDescriptors.put(new Transition<>(Rain.F, Rain.F), Descriptor.S2S);
 
         final ViterbiAlgorithm<Rain, Umbrella, Descriptor> viterbi = new ViterbiAlgorithm<>(true);
         viterbi.startWithInitialObservation(Umbrella.T, candidates,
@@ -154,7 +152,7 @@ public class ViterbiAlgorithmTest {
         assertEquals(Umbrella.F, result.get(2).observation);
         assertEquals(Umbrella.T, result.get(3).observation);
 
-        assertEquals(null,           result.get(0).transitionDescriptor);
+        assertNull(result.get(0).transitionDescriptor);
         assertEquals(Descriptor.R2R, result.get(1).transitionDescriptor);
         assertEquals(Descriptor.R2S, result.get(2).transitionDescriptor);
         assertEquals(Descriptor.S2R, result.get(3).transitionDescriptor);
@@ -209,7 +207,7 @@ public class ViterbiAlgorithmTest {
         final List<SequenceState<Rain, Umbrella, Descriptor>> result =
                 viterbi.computeMostLikelySequence();
 
-        assertEquals(Arrays.asList(), result);
+        assertEquals(Collections.emptyList(), result);
         assertFalse(viterbi.isBroken());
     }
 
@@ -225,7 +223,7 @@ public class ViterbiAlgorithmTest {
         emissionLogProbabilities.put(Rain.F, log(0.0));
         viterbi.startWithInitialObservation(Umbrella.T, candidates, emissionLogProbabilities);
         assertTrue(viterbi.isBroken());
-        assertEquals(Arrays.asList(), viterbi.computeMostLikelySequence());
+        assertEquals(Collections.emptyList(), viterbi.computeMostLikelySequence());
     }
 
     @Test
@@ -234,7 +232,7 @@ public class ViterbiAlgorithmTest {
         viterbi.startWithInitialObservation(Umbrella.T, new ArrayList<Rain>(),
                 new LinkedHashMap<Rain, Double>());
         assertTrue(viterbi.isBroken());
-        assertEquals(Arrays.asList(), viterbi.computeMostLikelySequence());
+        assertEquals(Collections.emptyList(), viterbi.computeMostLikelySequence());
     }
 
     @Test
@@ -251,15 +249,15 @@ public class ViterbiAlgorithmTest {
         assertFalse(viterbi.isBroken());
 
         final Map<Transition<Rain>, Double> transitionLogProbabilities = new LinkedHashMap<>();
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.T, Rain.T), log(0.0));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.T, Rain.F), log(0.0));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.F, Rain.T), log(0.0));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.F, Rain.F), log(0.0));
+        transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.T), log(0.0));
+        transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.F), log(0.0));
+        transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.T), log(0.0));
+        transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.F), log(0.0));
         viterbi.nextStep(Umbrella.T, candidates, emissionLogProbabilities,
                 transitionLogProbabilities);
 
         assertTrue(viterbi.isBroken());
-        assertEquals(Arrays.asList(Rain.T), states(viterbi.computeMostLikelySequence()));
+        assertEquals(Collections.singletonList(Rain.T), states(viterbi.computeMostLikelySequence()));
     }
 
     @Test
@@ -279,7 +277,7 @@ public class ViterbiAlgorithmTest {
                 new LinkedHashMap<Transition<Rain>, Double>());
         assertTrue(viterbi.isBroken());
 
-        assertEquals(Arrays.asList(Rain.T), states(viterbi.computeMostLikelySequence()));
+        assertEquals(Collections.singletonList(Rain.T), states(viterbi.computeMostLikelySequence()));
     }
 
     @Test
@@ -296,19 +294,19 @@ public class ViterbiAlgorithmTest {
         assertFalse(viterbi.isBroken());
 
         Map<Transition<Rain>, Double> transitionLogProbabilities = new LinkedHashMap<>();
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.T, Rain.T), log(0.5));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.T, Rain.F), log(0.5));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.F, Rain.T), log(0.5));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.F, Rain.F), log(0.5));
+        transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.T), log(0.5));
+        transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.F), log(0.5));
+        transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.T), log(0.5));
+        transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.F), log(0.5));
         viterbi.nextStep(Umbrella.T, candidates, emissionLogProbabilities,
                 transitionLogProbabilities);
         assertFalse(viterbi.isBroken());
 
         transitionLogProbabilities = new LinkedHashMap<>();
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.T, Rain.T), log(0.0));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.T, Rain.F), log(0.0));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.F, Rain.T), log(0.0));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.F, Rain.F), log(0.0));
+        transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.T), log(0.0));
+        transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.F), log(0.0));
+        transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.T), log(0.0));
+        transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.F), log(0.0));
         viterbi.nextStep(Umbrella.T, candidates, emissionLogProbabilities,
                 transitionLogProbabilities);
 
@@ -336,10 +334,10 @@ public class ViterbiAlgorithmTest {
         emissionLogProbabilitiesForNoUmbrella.put(Rain.T, log(0.5));
 
         final Map<Transition<Rain>, Double> transitionLogProbabilities = new LinkedHashMap<>();
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.F, Rain.T), log(0.5));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.F, Rain.F), log(0.5));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.T, Rain.T), log(0.5));
-        transitionLogProbabilities.put(new Transition<Rain>(Rain.T, Rain.F), log(0.5));
+        transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.T), log(0.5));
+        transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.F), log(0.5));
+        transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.T), log(0.5));
+        transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.F), log(0.5));
 
         final ViterbiAlgorithm<Rain, Umbrella, Descriptor> viterbi = new ViterbiAlgorithm<>(true);
         viterbi.startWithInitialObservation(Umbrella.T, candidates,

--- a/hmm-lib/src/test/java/com/bmw/hmm/ViterbiAlgorithmTest.java
+++ b/hmm-lib/src/test/java/com/bmw/hmm/ViterbiAlgorithmTest.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class ViterbiAlgorithmTest {
@@ -95,6 +96,15 @@ public class ViterbiAlgorithmTest {
         return result;
     }
 
+    private ViterbiAlgorithm<Rain, Umbrella, Descriptor> defaultViterbi;
+    private List<Rain> defaultCandidates;
+
+    @Before
+    public void before() {
+        defaultViterbi = new ViterbiAlgorithm<>();
+        defaultCandidates = Arrays.asList(Rain.T, Rain.F);
+    }
+
     /**
      * Tests the Viterbi algorithms with the umbrella example taken from Russell, Norvig: Aritifical
      * Intelligence - A Modern Approach, 3rd edition, chapter 15.2.3. Note that the probabilities in
@@ -103,10 +113,6 @@ public class ViterbiAlgorithmTest {
      */
     @Test
     public void testComputeMostLikelySequence() {
-        final List<Rain> candidates = new ArrayList<>();
-        candidates.add(Rain.T);
-        candidates.add(Rain.F);
-
         final Map<Rain, Double> emissionLogProbabilitiesForUmbrella = new LinkedHashMap<>();
         emissionLogProbabilitiesForUmbrella.put(Rain.T, log(0.9));
         emissionLogProbabilitiesForUmbrella.put(Rain.F, log(0.2));
@@ -128,13 +134,13 @@ public class ViterbiAlgorithmTest {
         transitionDescriptors.put(new Transition<>(Rain.F, Rain.F), Descriptor.S2S);
 
         final ViterbiAlgorithm<Rain, Umbrella, Descriptor> viterbi = new ViterbiAlgorithm<>(true);
-        viterbi.startWithInitialObservation(Umbrella.T, candidates,
+        viterbi.startWithInitialObservation(Umbrella.T, defaultCandidates,
                 emissionLogProbabilitiesForUmbrella);
-        viterbi.nextStep(Umbrella.T, candidates, emissionLogProbabilitiesForUmbrella,
+        viterbi.nextStep(Umbrella.T, defaultCandidates, emissionLogProbabilitiesForUmbrella,
                 transitionLogProbabilities, transitionDescriptors);
-        viterbi.nextStep(Umbrella.F, candidates, emissionLogProbabilitiesForNoUmbrella,
+        viterbi.nextStep(Umbrella.F, defaultCandidates, emissionLogProbabilitiesForNoUmbrella,
                 transitionLogProbabilities, transitionDescriptors);
-        viterbi.nextStep(Umbrella.T, candidates, emissionLogProbabilitiesForUmbrella,
+        viterbi.nextStep(Umbrella.T, defaultCandidates, emissionLogProbabilitiesForUmbrella,
                 transitionLogProbabilities, transitionDescriptors);
 
         final List<SequenceState<Rain, Umbrella, Descriptor>> result =
@@ -203,115 +209,93 @@ public class ViterbiAlgorithmTest {
 
     @Test
     public void testEmptySequence() {
-        final ViterbiAlgorithm<Rain, Umbrella, Descriptor> viterbi = new ViterbiAlgorithm<>();
         final List<SequenceState<Rain, Umbrella, Descriptor>> result =
-                viterbi.computeMostLikelySequence();
+                defaultViterbi.computeMostLikelySequence();
 
         assertEquals(Collections.emptyList(), result);
-        assertFalse(viterbi.isBroken());
+        assertFalse(defaultViterbi.isBroken());
     }
 
     @Test
     public void testBreakAtInitialMessage() {
-        final ViterbiAlgorithm<Rain, Umbrella, Descriptor> viterbi = new ViterbiAlgorithm<>();
-        final List<Rain> candidates = new ArrayList<>();
-        candidates.add(Rain.T);
-        candidates.add(Rain.F);
-
         final Map<Rain, Double> emissionLogProbabilities = new LinkedHashMap<>();
         emissionLogProbabilities.put(Rain.T, log(0.0));
         emissionLogProbabilities.put(Rain.F, log(0.0));
-        viterbi.startWithInitialObservation(Umbrella.T, candidates, emissionLogProbabilities);
-        assertTrue(viterbi.isBroken());
-        assertEquals(Collections.emptyList(), viterbi.computeMostLikelySequence());
+        defaultViterbi.startWithInitialObservation(Umbrella.T, defaultCandidates, emissionLogProbabilities);
+        assertTrue(defaultViterbi.isBroken());
+        assertEquals(Collections.emptyList(), defaultViterbi.computeMostLikelySequence());
     }
 
     @Test
     public void testEmptyInitialMessage() {
-        final ViterbiAlgorithm<Rain, Umbrella, Descriptor> viterbi = new ViterbiAlgorithm<>();
-        viterbi.startWithInitialObservation(Umbrella.T, new ArrayList<Rain>(),
+        defaultViterbi.startWithInitialObservation(Umbrella.T, new ArrayList<Rain>(),
                 new LinkedHashMap<Rain, Double>());
-        assertTrue(viterbi.isBroken());
-        assertEquals(Collections.emptyList(), viterbi.computeMostLikelySequence());
+        assertTrue(defaultViterbi.isBroken());
+        assertEquals(Collections.emptyList(), defaultViterbi.computeMostLikelySequence());
     }
 
     @Test
     public void testBreakAtFirstTransition() {
-        final ViterbiAlgorithm<Rain, Umbrella, Descriptor> viterbi = new ViterbiAlgorithm<>();
-        final List<Rain> candidates = new ArrayList<>();
-        candidates.add(Rain.T);
-        candidates.add(Rain.F);
-
         final Map<Rain, Double> emissionLogProbabilities = new LinkedHashMap<>();
         emissionLogProbabilities.put(Rain.T, log(0.9));
         emissionLogProbabilities.put(Rain.F, log(0.2));
-        viterbi.startWithInitialObservation(Umbrella.T, candidates, emissionLogProbabilities);
-        assertFalse(viterbi.isBroken());
+        defaultViterbi.startWithInitialObservation(Umbrella.T, defaultCandidates, emissionLogProbabilities);
+        assertFalse(defaultViterbi.isBroken());
 
         final Map<Transition<Rain>, Double> transitionLogProbabilities = new LinkedHashMap<>();
         transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.T), log(0.0));
         transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.F), log(0.0));
         transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.T), log(0.0));
         transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.F), log(0.0));
-        viterbi.nextStep(Umbrella.T, candidates, emissionLogProbabilities,
+        defaultViterbi.nextStep(Umbrella.T, defaultCandidates, emissionLogProbabilities,
                 transitionLogProbabilities);
 
-        assertTrue(viterbi.isBroken());
-        assertEquals(Collections.singletonList(Rain.T), states(viterbi.computeMostLikelySequence()));
+        assertTrue(defaultViterbi.isBroken());
+        assertEquals(Collections.singletonList(Rain.T), states(defaultViterbi.computeMostLikelySequence()));
     }
 
     @Test
     public void testBreakAtFirstTransitionWithNoCandidates() {
-        final ViterbiAlgorithm<Rain, Umbrella, Descriptor> viterbi = new ViterbiAlgorithm<>();
-        final List<Rain> candidates = new ArrayList<>();
-        candidates.add(Rain.T);
-        candidates.add(Rain.F);
-
         final Map<Rain, Double> emissionLogProbabilities = new LinkedHashMap<>();
         emissionLogProbabilities.put(Rain.T, log(0.9));
         emissionLogProbabilities.put(Rain.F, log(0.2));
-        viterbi.startWithInitialObservation(Umbrella.T, candidates, emissionLogProbabilities);
-        assertFalse(viterbi.isBroken());
+        defaultViterbi.startWithInitialObservation(Umbrella.T, defaultCandidates, emissionLogProbabilities);
+        assertFalse(defaultViterbi.isBroken());
 
-        viterbi.nextStep(Umbrella.T, new ArrayList<Rain>(), new LinkedHashMap<Rain, Double>(),
+        defaultViterbi.nextStep(Umbrella.T, new ArrayList<Rain>(), new LinkedHashMap<Rain, Double>(),
                 new LinkedHashMap<Transition<Rain>, Double>());
-        assertTrue(viterbi.isBroken());
+        assertTrue(defaultViterbi.isBroken());
 
-        assertEquals(Collections.singletonList(Rain.T), states(viterbi.computeMostLikelySequence()));
+        assertEquals(Collections.singletonList(Rain.T), states(defaultViterbi.computeMostLikelySequence()));
     }
 
     @Test
     public void testBreakAtSecondTransition() {
-        final ViterbiAlgorithm<Rain, Umbrella, Descriptor> viterbi = new ViterbiAlgorithm<>();
-        final List<Rain> candidates = new ArrayList<>();
-        candidates.add(Rain.T);
-        candidates.add(Rain.F);
-
         final Map<Rain, Double> emissionLogProbabilities = new LinkedHashMap<>();
         emissionLogProbabilities.put(Rain.T, log(0.9));
         emissionLogProbabilities.put(Rain.F, log(0.2));
-        viterbi.startWithInitialObservation(Umbrella.T, candidates, emissionLogProbabilities);
-        assertFalse(viterbi.isBroken());
+        defaultViterbi.startWithInitialObservation(Umbrella.T, defaultCandidates, emissionLogProbabilities);
+        assertFalse(defaultViterbi.isBroken());
 
         Map<Transition<Rain>, Double> transitionLogProbabilities = new LinkedHashMap<>();
         transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.T), log(0.5));
         transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.F), log(0.5));
         transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.T), log(0.5));
         transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.F), log(0.5));
-        viterbi.nextStep(Umbrella.T, candidates, emissionLogProbabilities,
+        defaultViterbi.nextStep(Umbrella.T, defaultCandidates, emissionLogProbabilities,
                 transitionLogProbabilities);
-        assertFalse(viterbi.isBroken());
+        assertFalse(defaultViterbi.isBroken());
 
         transitionLogProbabilities = new LinkedHashMap<>();
         transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.T), log(0.0));
         transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.F), log(0.0));
         transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.T), log(0.0));
         transitionLogProbabilities.put(new Transition<>(Rain.F, Rain.F), log(0.0));
-        viterbi.nextStep(Umbrella.T, candidates, emissionLogProbabilities,
+        defaultViterbi.nextStep(Umbrella.T, defaultCandidates, emissionLogProbabilities,
                 transitionLogProbabilities);
 
-        assertTrue(viterbi.isBroken());
-        assertEquals(Arrays.asList(Rain.T, Rain.T), states(viterbi.computeMostLikelySequence()));
+        assertTrue(defaultViterbi.isBroken());
+        assertEquals(Arrays.asList(Rain.T, Rain.T), states(defaultViterbi.computeMostLikelySequence()));
     }
 
     @Test
@@ -319,10 +303,6 @@ public class ViterbiAlgorithmTest {
      * Checks if the first candidate is returned if multiple candidates are equally likely.
      */
     public void testDeterministicCandidateOrder() {
-        final List<Rain> candidates = new ArrayList<>();
-        candidates.add(Rain.T);
-        candidates.add(Rain.F);
-
         // Reverse usual order of emission and transition probabilities keys since their order
         // should not matter.
         final Map<Rain, Double> emissionLogProbabilitiesForUmbrella = new LinkedHashMap<>();
@@ -340,13 +320,13 @@ public class ViterbiAlgorithmTest {
         transitionLogProbabilities.put(new Transition<>(Rain.T, Rain.F), log(0.5));
 
         final ViterbiAlgorithm<Rain, Umbrella, Descriptor> viterbi = new ViterbiAlgorithm<>(true);
-        viterbi.startWithInitialObservation(Umbrella.T, candidates,
+        viterbi.startWithInitialObservation(Umbrella.T, defaultCandidates,
                 emissionLogProbabilitiesForUmbrella);
-        viterbi.nextStep(Umbrella.T, candidates, emissionLogProbabilitiesForUmbrella,
+        viterbi.nextStep(Umbrella.T, defaultCandidates, emissionLogProbabilitiesForUmbrella,
                 transitionLogProbabilities);
-        viterbi.nextStep(Umbrella.F, candidates, emissionLogProbabilitiesForNoUmbrella,
+        viterbi.nextStep(Umbrella.F, defaultCandidates, emissionLogProbabilitiesForNoUmbrella,
                 transitionLogProbabilities);
-        viterbi.nextStep(Umbrella.T, candidates, emissionLogProbabilitiesForUmbrella,
+        viterbi.nextStep(Umbrella.T, defaultCandidates, emissionLogProbabilitiesForUmbrella,
                 transitionLogProbabilities);
 
         final List<SequenceState<Rain, Umbrella, Descriptor>> result =

--- a/matching-core/pom.xml
+++ b/matching-core/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-map-matching-core</artifactId>
     <version>0.13-SNAPSHOT</version>
     <packaging>jar</packaging>

--- a/matching-core/src/main/java/com/graphhopper/matching/util/HmmProbabilities.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/util/HmmProbabilities.java
@@ -58,7 +58,7 @@ public class HmmProbabilities {
      */
     public double transitionLogProbability(double routeLength, double linearDistance) {
         // Transition metric taken from Newson & Krumm.
-        Double transitionMetric = Math.abs(linearDistance - routeLength);
+        double transitionMetric = Math.abs(linearDistance - routeLength);
 
         return Distributions.logExponentialDistribution(beta, transitionMetric);
     }

--- a/matching-web-bundle/pom.xml
+++ b/matching-web-bundle/pom.xml
@@ -3,7 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-map-matching-web-bundle</artifactId>
     <packaging>jar</packaging>
     <version>0.13-SNAPSHOT</version>

--- a/matching-web/pom.xml
+++ b/matching-web/pom.xml
@@ -3,7 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-map-matching-web</artifactId>
     <packaging>jar</packaging>
     <version>0.13-SNAPSHOT</version>


### PR DESCRIPTION
Small refactoring:

- Removed groupId from the pom files where it is inherited from parent

- Initialize default objects for testing to make the tests more compact

- Other small parts of code were refactored