### PR TITLE
Upgrade GH core to 1.0-pre4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <slf4j.version>1.7.26</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
-        <gh.version>1.0-pre3</gh.version>
+        <gh.version>1.0-pre4</gh.version>
 
         <dropwizard.version>1.3.12</dropwizard.version>
         <jackson.version>2.9.9</jackson.version>


### PR DESCRIPTION
There is a huge delay for MapMatchingTest when switching from 1.0-pre3 to pre4

There seems to be a problem in [MapMatching.createVirtualEdgesMap](https://github.com/graphhopper/map-matching/blob/master/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java#L617). Is this due to https://github.com/graphhopper/graphhopper/pull/1751 ? Maybe traverseToClosestRealAdj is too slow now or some infinite/recursive loop without end?