### PR TITLE
Use GH core 1.0-pre33

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ OpenStreetMap data in pbf or xml format are available from [here](http://downloa
 
 The optional parameter `--vehicle` defines the routing profile like `car`, `bike`, `motorcycle` or `foot`.
 You can also provide a comma separated list. For all supported values see the variables in the [FlagEncoderFactory](https://github.com/graphhopper/graphhopper/blob/0.13/core/src/main/java/com/graphhopper/routing/util/FlagEncoderFactory.java) of GraphHopper.
-By default `car` will be used. If you change the default for the import you will also have to change it for the match command. 
 
 Before re-importing, you need to delete the `graph-cache` directory, which is created by the import.
 
@@ -50,6 +49,8 @@ Now you can match GPX traces against the map:
 ```bash
 java -jar matching-web/target/graphhopper-map-matching-web-1.0-SNAPSHOT.jar match matching-web/src/test/resources/*.gpx
 ```
+If you were using multiple vehicles for the import you can use `--vehicle` to select one of them, otherwise the first
+one will be used.
 
 ### Web app
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ java -jar matching-web/target/graphhopper-map-matching-web-1.0-SNAPSHOT.jar impo
 OpenStreetMap data in pbf or xml format are available from [here](http://download.geofabrik.de/).
 
 The optional parameter `--vehicle` defines the routing profile like `car`, `bike`, `motorcycle` or `foot`.
-You can also provide a comma separated list. For all supported values see the variables in the [FlagEncoderFactory](https://github.com/graphhopper/graphhopper/blob/0.13/core/src/main/java/com/graphhopper/routing/util/FlagEncoderFactory.java) of GraphHopper. 
+You can also provide a comma separated list. For all supported values see the variables in the [FlagEncoderFactory](https://github.com/graphhopper/graphhopper/blob/0.13/core/src/main/java/com/graphhopper/routing/util/FlagEncoderFactory.java) of GraphHopper.
+By default `car` will be used. If you change the default for the import you will also have to change it for the match command. 
 
 Before re-importing, you need to delete the `graph-cache` directory, which is created by the import.
 

--- a/config.yml
+++ b/config.yml
@@ -2,6 +2,10 @@ graphhopper:
   datareader.file: map-data/leipzig_germany.osm.pbf # OSM input file (example data)
   graph.location: graph-cache
   graph.flag_encoders: car
+  profiles:
+    - name: car
+      vehicle: car
+      weighting: fastest
 
 server:
   application_connectors:

--- a/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
@@ -80,6 +80,11 @@ public class MapMatching {
     public MapMatching(GraphHopper graphHopper, PMap hints) {
         this.locationIndex = (LocationIndexTree) graphHopper.getLocationIndex();
 
+        if (hints.has("vehicle"))
+            throw new IllegalArgumentException("MapMatching hints may no longer contain a vehicle, use the profile parameter instead, see core/#1958");
+        if (hints.has("weighting"))
+            throw new IllegalArgumentException("MapMatching hints may no longer contain a weighting, use the profile parameter instead, see core/#1958");
+
         if (graphHopper.getProfiles().isEmpty()) {
             throw new IllegalArgumentException("No profiles found, you need to configure at least one profile to use map matching");
         }

--- a/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
@@ -29,7 +29,6 @@ import com.graphhopper.routing.querygraph.QueryGraph;
 import com.graphhopper.routing.querygraph.VirtualEdgeIteratorState;
 import com.graphhopper.routing.util.DefaultEdgeFilter;
 import com.graphhopper.routing.util.EdgeFilter;
-import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
@@ -78,10 +77,26 @@ public class MapMatching {
     private final boolean ch;
     private QueryGraph queryGraph;
 
-    public MapMatching(GraphHopper graphHopper, HintsMap hints) {
+    public MapMatching(GraphHopper graphHopper, PMap hints) {
         this.locationIndex = (LocationIndexTree) graphHopper.getLocationIndex();
 
-        if (!hints.has("vehicle")) hints.putObject("vehicle", "car");
+        if (graphHopper.getProfiles().isEmpty()) {
+            throw new IllegalArgumentException("No profiles found, you need to configure at least one profile to use map matching");
+        }
+        if (!hints.has("profile")) {
+            throw new IllegalArgumentException("You need to specify a profile to perform map matching");
+        }
+        ProfileConfig profile = null;
+        String profileStr = hints.getString("profile", "");
+        List<String> profiles = new ArrayList<>(graphHopper.getProfiles().size());
+        for (ProfileConfig p : graphHopper.getProfiles()) {
+            profiles.add(p.getName());
+            if (p.getName().equals(profileStr)) {
+                profile = p;
+            }
+        }
+        if (profile == null)
+            throw new IllegalArgumentException("Could not find profile '" + profileStr + "', choose one of: " + profiles);
 
         // Convert heading penalty [s] into U-turn penalty [m]
         // The heading penalty is automatically taken into account by GraphHopper routing,
@@ -94,7 +109,6 @@ public class MapMatching {
         final double headingTimePenalty = hints.getDouble(Parameters.Routing.HEADING_PENALTY, Parameters.Routing.DEFAULT_HEADING_PENALTY);
         uTurnDistancePenalty = headingTimePenalty * PENALTY_CONVERSION_VELOCITY;
 
-        ProfileConfig profile = graphHopper.resolveProfile(hints);
         boolean disableCH = hints.getBool(Parameters.CH.DISABLE, false);
         boolean disableLM = hints.getBool(Parameters.Landmark.DISABLE, false);
         RoutingAlgorithmFactory routingAlgorithmFactory = graphHopper.getAlgorithmFactory(profile.getName(), disableCH, disableLM);

--- a/matching-web-bundle/src/main/java/com/graphhopper/matching/http/MapMatchingResource.java
+++ b/matching-web-bundle/src/main/java/com/graphhopper/matching/http/MapMatchingResource.java
@@ -24,9 +24,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.graphhopper.GHResponse;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.PathWrapper;
+import com.graphhopper.config.ProfileConfig;
 import com.graphhopper.http.WebHelper;
 import com.graphhopper.matching.*;
 import com.graphhopper.matching.gpx.Gpx;
+import com.graphhopper.routing.ProfileResolver;
 import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.util.*;
 import com.graphhopper.util.gpx.GpxFromInstructions;
@@ -53,11 +55,13 @@ public class MapMatchingResource {
     private static final Logger logger = LoggerFactory.getLogger(MapMatchingResource.class);
 
     private final GraphHopper graphHopper;
+    private final ProfileResolver profileResolver;
     private final TranslationMap trMap;
 
     @Inject
-    public MapMatchingResource(GraphHopper graphHopper, TranslationMap trMap) {
+    public MapMatchingResource(GraphHopper graphHopper, ProfileResolver profileResolver, TranslationMap trMap) {
         this.graphHopper = graphHopper;
+        this.profileResolver = profileResolver;
         this.trMap = trMap;
     }
 
@@ -95,9 +99,17 @@ public class MapMatchingResource {
 
         StopWatch sw = new StopWatch().start();
 
-        MapMatching matching = new MapMatching(graphHopper,
-                // set default values from annotation for certain keys
-                createHintsMap(uriInfo.getQueryParameters()).setVehicle(vehicleStr).putObject(MAX_VISITED_NODES, maxVisitedNodes));
+        HintsMap hints = createHintsMap(uriInfo.getQueryParameters());
+        // add values that are not in hints because they were explicitly listed in query params
+        hints.setVehicle(vehicleStr);
+        hints.putObject(MAX_VISITED_NODES, maxVisitedNodes);
+        // resolve profile and remove legacy vehicle/weighting parameters
+        String profile = profileResolver.resolveProfile(hints).getName();
+        hints.setVehicle("");
+        hints.setWeighting("");
+        hints.putObject("profile", profile);
+
+        MapMatching matching = new MapMatching(graphHopper, hints);
         matching.setMeasurementErrorSigma(gpsAccuracy);
 
         List<Observation> measurements = gpx.trk.get(0).getEntries();
@@ -166,7 +178,7 @@ public class MapMatchingResource {
         HintsMap m = new HintsMap();
         for (Map.Entry<String, List<String>> e : queryParameters.entrySet()) {
             if (e.getValue().size() == 1) {
-                m.put(e.getKey(), e.getValue().get(0));
+                m.putObject(Helper.camelCaseToUnderScore(e.getKey()), Helper.toObject(e.getValue().get(0)));
             } else {
                 // TODO ugly: ignore multi parameters like point to avoid exception. See RouteResource.initHints
             }

--- a/matching-web-bundle/src/main/java/com/graphhopper/matching/http/MapMatchingResource.java
+++ b/matching-web-bundle/src/main/java/com/graphhopper/matching/http/MapMatchingResource.java
@@ -105,8 +105,8 @@ public class MapMatchingResource {
         hints.putObject(MAX_VISITED_NODES, maxVisitedNodes);
         // resolve profile and remove legacy vehicle/weighting parameters
         String profile = profileResolver.resolveProfile(hints).getName();
-        hints.setVehicle("");
-        hints.setWeighting("");
+        hints.remove("vehicle");
+        hints.remove("weighting");
         hints.putObject("profile", profile);
 
         MapMatching matching = new MapMatching(graphHopper, hints);

--- a/matching-web/src/main/java/com/graphhopper/matching/cli/ImportCommand.java
+++ b/matching-web/src/main/java/com/graphhopper/matching/cli/ImportCommand.java
@@ -2,11 +2,14 @@ package com.graphhopper.matching.cli;
 
 import com.graphhopper.GraphHopper;
 import com.graphhopper.GraphHopperConfig;
+import com.graphhopper.config.ProfileConfig;
 import com.graphhopper.reader.osm.GraphHopperOSM;
 import io.dropwizard.cli.Command;
 import io.dropwizard.setup.Bootstrap;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
+
+import java.util.Collections;
 
 public class ImportCommand extends Command {
 
@@ -28,9 +31,13 @@ public class ImportCommand extends Command {
     @Override
     public void run(Bootstrap<?> bootstrap, Namespace args) {
         GraphHopperConfig graphHopperConfiguration = new GraphHopperConfig();
-        graphHopperConfiguration.putObject("graph.flag_encoders", args.getString("vehicle"));
+        String vehicle = args.getString("vehicle");
+        graphHopperConfiguration.putObject("graph.flag_encoders", vehicle);
         graphHopperConfiguration.putObject("datareader.file", args.getString("datasource"));
         graphHopperConfiguration.putObject("graph.location", "graph-cache");
+        // always using fastest weighting, see comment in MatchCommand
+        String weightingStr = "fastest";
+        graphHopperConfiguration.setProfiles(Collections.singletonList(new ProfileConfig("profile").setVehicle(vehicle).setWeighting(weightingStr)));
 
         GraphHopper hopper = new GraphHopperOSM().init(graphHopperConfiguration);
         hopper.importOrLoad();

--- a/matching-web/src/main/java/com/graphhopper/matching/cli/ImportCommand.java
+++ b/matching-web/src/main/java/com/graphhopper/matching/cli/ImportCommand.java
@@ -9,7 +9,8 @@ import io.dropwizard.setup.Bootstrap;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ImportCommand extends Command {
 
@@ -37,8 +38,12 @@ public class ImportCommand extends Command {
         graphHopperConfiguration.putObject("graph.location", "graph-cache");
         // always using fastest weighting, see comment in MatchCommand
         String weightingStr = "fastest";
-        graphHopperConfiguration.setProfiles(Collections.singletonList(new ProfileConfig("profile").setVehicle(vehicle).setWeighting(weightingStr)));
-
+        List<ProfileConfig> profiles = new ArrayList<>();
+        for (String v : vehicle.split(",")) {
+            v = v.trim();
+            profiles.add(new ProfileConfig(v + "_profile").setVehicle(v).setWeighting(weightingStr));
+        }
+        graphHopperConfiguration.setProfiles(profiles);
         GraphHopper hopper = new GraphHopperOSM().init(graphHopperConfiguration);
         hopper.importOrLoad();
     }

--- a/matching-web/src/main/java/com/graphhopper/matching/cli/MatchCommand.java
+++ b/matching-web/src/main/java/com/graphhopper/matching/cli/MatchCommand.java
@@ -4,14 +4,12 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.GraphHopperConfig;
 import com.graphhopper.PathWrapper;
+import com.graphhopper.config.ProfileConfig;
 import com.graphhopper.matching.MapMatching;
 import com.graphhopper.matching.MatchResult;
 import com.graphhopper.matching.Observation;
 import com.graphhopper.matching.gpx.Gpx;
 import com.graphhopper.reader.osm.GraphHopperOSM;
-import com.graphhopper.routing.util.FlagEncoder;
-import com.graphhopper.routing.util.HintsMap;
-import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.util.*;
 import com.graphhopper.util.gpx.GpxFromInstructions;
@@ -67,15 +65,19 @@ public class MatchCommand extends Command {
         graphHopperConfiguration.putObject("graph.location", "graph-cache");
         GraphHopper hopper = new GraphHopperOSM().init(graphHopperConfiguration);
         System.out.println("loading graph from cache");
-        hopper.load(graphHopperConfiguration.getString("graph.location", "graph-cache"));
-
+        // since we are loading GraphHopper from disk we more or less have to guess the configuration
         String vehicle = args.getString("vehicle");
-        FlagEncoder encoder = Helper.isEmpty(vehicle) ? hopper.getEncodingManager().fetchEdgeEncoders().get(0) : hopper.getEncodingManager().getEncoder(vehicle);
+        if (Helper.isEmpty(vehicle))
+            vehicle = hopper.getEncodingManager().fetchEdgeEncoders().get(0).toString();
+
         // Penalizing inner-link U-turns only works with fastest weighting, since
         // shortest weighting does not apply penalties to unfavored virtual edges.
-        HintsMap hintsMap = new HintsMap().setWeighting("fastest").setVehicle(encoder.toString()).putObject(MAX_VISITED_NODES, args.getInt("max_visited_nodes"));
-        Weighting weighting = new FastestWeighting(encoder);
-        MapMatching mapMatching = new MapMatching(hopper, hintsMap);
+        String weightingStr = "fastest";
+        hopper.setProfiles(new ProfileConfig("profile").setVehicle(vehicle).setWeighting(weightingStr).setTurnCosts(false));
+        hopper.load(graphHopperConfiguration.getString("graph.location", "graph-cache"));
+
+        PMap hints = new PMap().putObject(MAX_VISITED_NODES, args.get("max_visited_nodes"));
+        MapMatching mapMatching = new MapMatching(hopper, hints);
         mapMatching.setTransitionProbabilityBeta(args.getDouble("transition_probability_beta"));
         mapMatching.setMeasurementErrorSigma(args.getInt("gps_accuracy"));
 
@@ -85,6 +87,8 @@ public class MatchCommand extends Command {
         Translation tr = new TranslationMap().doImport().getWithFallBack(Helper.getLocale(args.getString("instructions")));
         final boolean withRoute = !args.getString("instructions").isEmpty();
         XmlMapper xmlMapper = new XmlMapper();
+
+        Weighting weighting = hopper.createWeighting(hopper.getProfiles().get(0), hints);
 
         for (File gpxFile : args.<File>getList("gpx")) {
             try {

--- a/matching-web/src/main/java/com/graphhopper/matching/cli/MeasurementCommand.java
+++ b/matching-web/src/main/java/com/graphhopper/matching/cli/MeasurementCommand.java
@@ -21,6 +21,7 @@ import com.graphhopper.GHRequest;
 import com.graphhopper.GHResponse;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.GraphHopperConfig;
+import com.graphhopper.config.ProfileConfig;
 import com.graphhopper.matching.MapMatching;
 import com.graphhopper.matching.MatchResult;
 import com.graphhopper.matching.Observation;
@@ -42,12 +43,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Random;
-import java.util.TreeMap;
 
 /**
  * @author Peter Karisch
@@ -87,6 +84,7 @@ public class MeasurementCommand extends Command {
     public void run(Bootstrap bootstrap, Namespace args) {
         // read and initialize arguments:
         GraphHopperConfig graphHopperConfiguration = new GraphHopperConfig();
+        graphHopperConfiguration.setProfiles(Collections.singletonList(new ProfileConfig("fast_car").setVehicle("car").setWeighting("fastest")));
         graphHopperConfiguration.putObject("graph.location", "graph-cache");
         seed = args.getLong("seed");
         count = args.getInt("count");
@@ -99,7 +97,7 @@ public class MeasurementCommand extends Command {
         GraphHopperStorage graph = graphHopper.getGraphHopperStorage();
         bbox = graph.getBounds();
         LocationIndexTree locationIndex = (LocationIndexTree) graphHopper.getLocationIndex();
-        MapMatching mapMatching = new MapMatching(graphHopper, new HintsMap());
+        MapMatching mapMatching = new MapMatching(graphHopper, new HintsMap().putObject("profile", "fast_car"));
         
         // start tests:
         StopWatch sw = new StopWatch().start();

--- a/matching-web/src/test/java/com/graphhopper/matching/MapMatching2Test.java
+++ b/matching-web/src/test/java/com/graphhopper/matching/MapMatching2Test.java
@@ -64,7 +64,7 @@ public class MapMatching2Test {
         hopper.getCHPreparationHandler().setDisablingAllowed(true);
         hopper.importOrLoad();
 
-        MapMatching mapMatching = new MapMatching(hopper, new HintsMap());
+        MapMatching mapMatching = new MapMatching(hopper, new HintsMap().putObject("profile", "my_profile"));
 
         Gpx gpx = xmlMapper.readValue(getClass().getResourceAsStream("/issue-13.gpx"), Gpx.class);
         MatchResult mr = mapMatching.doWork(gpx.trk.get(0).getEntries());
@@ -96,7 +96,7 @@ public class MapMatching2Test {
         hopper.getCHPreparationHandler().setDisablingAllowed(true);
         hopper.importOrLoad();
 
-        MapMatching mapMatching = new MapMatching(hopper, new HintsMap());
+        MapMatching mapMatching = new MapMatching(hopper, new HintsMap().putObject("profile", "my_profile"));
 
         Gpx gpx = xmlMapper.readValue(getClass().getResourceAsStream("/issue-70.gpx"), Gpx.class);
         MatchResult mr = mapMatching.doWork(gpx.trk.get(0).getEntries());
@@ -123,7 +123,7 @@ public class MapMatching2Test {
         hopper.getCHPreparationHandler().setDisablingAllowed(true);
         hopper.importOrLoad();
 
-        MapMatching mapMatching = new MapMatching(hopper, new HintsMap());
+        MapMatching mapMatching = new MapMatching(hopper, new HintsMap().putObject("profile", "my_profile"));
 
         // query with two identical points
         Gpx gpx = xmlMapper.readValue(getClass().getResourceAsStream("/issue-127.gpx"), Gpx.class);

--- a/matching-web/src/test/java/com/graphhopper/matching/RoutingAdditivityTest.java
+++ b/matching-web/src/test/java/com/graphhopper/matching/RoutingAdditivityTest.java
@@ -64,14 +64,14 @@ public class RoutingAdditivityTest {
         PathWrapper route1 = graphHopper.route(new GHRequest(
                 new GHPoint(51.23, 12.18),
                 new GHPoint(51.45, 12.59))
-                .setWeighting("fastest")).getBest();
+                .setProfile("my_profile")).getBest();
 
         // Re-route from snapped point to snapped point.
         // It's the only way to be sure.
         PathWrapper route2 = graphHopper.route(new GHRequest(
                 route1.getWaypoints().get(0),
                 route1.getWaypoints().get(1))
-                .setWeighting("fastest")).getBest();
+                .setProfile("my_profile")).getBest();
 
         assertThat(route1.getTime(), is(equalTo(route2.getTime())));
 
@@ -80,7 +80,7 @@ public class RoutingAdditivityTest {
             PathWrapper segment = graphHopper.route(new GHRequest(
                     route2.getPoints().get(i),
                     route2.getPoints().get(i + 1))
-                    .setWeighting("fastest")).getBest();
+                    .setProfile("my_profile")).getBest();
             travelTime += segment.getTime();
         }
 

--- a/matching-web/src/test/java/com/graphhopper/matching/http/MapMatchingResourceBikeTest.java
+++ b/matching-web/src/test/java/com/graphhopper/matching/http/MapMatchingResourceBikeTest.java
@@ -18,6 +18,7 @@
 package com.graphhopper.matching.http;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.graphhopper.config.ProfileConfig;
 import com.graphhopper.http.WebHelper;
 import com.graphhopper.util.Helper;
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -28,27 +29,29 @@ import org.junit.Test;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import java.io.File;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * @author Peter Karich
  */
-public class MapMatchingResource2Test {
+public class MapMatchingResourceBikeTest {
 
     private static final String DIR = "../target/mapmatching2test";
 
-    private static final MapMatchingServerConfiguration config = new MapMatchingServerConfiguration();
-
-    static {
+    private static MapMatchingServerConfiguration createConfig() {
+        MapMatchingServerConfiguration config = new MapMatchingServerConfiguration();
         config.getGraphHopperConfiguration().
                 putObject("graph.flag_encoders", "bike").
                 putObject("datareader.file", "../map-data/leipzig_germany.osm.pbf").
-                putObject("graph.location", DIR);
+                putObject("graph.location", DIR).
+                setProfiles(Collections.singletonList(new ProfileConfig("fast_bike").setVehicle("bike").setWeighting("fastest")));
+        return config;
     }
 
     @ClassRule
-    public static final DropwizardAppRule<MapMatchingServerConfiguration> app = new DropwizardAppRule(MapMatchingApplication.class, config);
+    public static final DropwizardAppRule<MapMatchingServerConfiguration> app = new DropwizardAppRule(MapMatchingApplication.class, createConfig());
 
     @AfterClass
     public static void cleanUp() {

--- a/matching-web/src/test/java/com/graphhopper/matching/http/MapMatchingResourceTest.java
+++ b/matching-web/src/test/java/com/graphhopper/matching/http/MapMatchingResourceTest.java
@@ -18,6 +18,7 @@
 package com.graphhopper.matching.http;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.graphhopper.config.ProfileConfig;
 import com.graphhopper.http.WebHelper;
 import com.graphhopper.util.Helper;
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -28,6 +29,7 @@ import org.junit.Test;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import java.io.File;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -39,17 +41,18 @@ public class MapMatchingResourceTest {
 
     private static final String DIR = "../target/mapmatchingtest";
 
-    private static final MapMatchingServerConfiguration config = new MapMatchingServerConfiguration();
-
-    static {
+    private static MapMatchingServerConfiguration createConfig() {
+        MapMatchingServerConfiguration config = new MapMatchingServerConfiguration();
         config.getGraphHopperConfiguration().
                 putObject("graph.flag_encoders", "car").
                 putObject("datareader.file", "../map-data/leipzig_germany.osm.pbf").
-                putObject("graph.location", DIR);
+                putObject("graph.location", DIR).
+                setProfiles(Collections.singletonList(new ProfileConfig("profile").setVehicle("car").setWeighting("fastest")));
+        return config;
     }
 
     @ClassRule
-    public static final DropwizardAppRule<MapMatchingServerConfiguration> app = new DropwizardAppRule<>(MapMatchingApplication.class, config);
+    public static final DropwizardAppRule<MapMatchingServerConfiguration> app = new DropwizardAppRule<>(MapMatchingApplication.class, createConfig());
 
     @AfterClass
     public static void cleanUp() {

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <slf4j.version>1.7.26</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
-        <gh.version>1.0-pre32</gh.version>
+        <gh.version>1.0-pre33</gh.version>
 
         <dropwizard.version>1.3.12</dropwizard.version>
         <jackson.version>2.9.9</jackson.version>


### PR DESCRIPTION
Updates core to 1.0-pre33. MapMatching is now taking a PMap that must contain a profile string matching one of the (now required) routing profiles. MapMatchingResource is still (only) using the vehicle/weighting parameters which are mapped to one of the available profiles using ProfileResolver. So starting with this version map matching config requires a profile section (not only when CH is used), but the web-api should still be working as before. The profile parameter for the web API will be added afterwards.