### PR TITLE
Use LM instead of CH

### DIFF
--- a/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
@@ -121,7 +121,16 @@ public class MapMatching {
         if (graphHopper.getLMPreparationHandler().isEnabled() && disableLM && !graphHopper.getRouterConfig().isLMDisablingAllowed())
             throw new IllegalArgumentException("Disabling LM is not allowed");
 
-        if (graphHopper.getLMPreparationHandler().isEnabled() && !disableLM) {
+        boolean disableCH = hints.getBool(Parameters.CH.DISABLE, false);
+        if (graphHopper.getCHPreparationHandler().isEnabled() && disableCH && !graphHopper.getRouterConfig().isCHDisablingAllowed())
+            throw new IllegalArgumentException("Disabling CH is not allowed");
+
+        // see map-matching/#177: both ch.disable and lm.disable can be used to force Dijkstra which is the better
+        // (=faster) choice when the gpx points are close to each other
+        boolean useDijkstra = disableLM || disableCH;
+
+        if (graphHopper.getLMPreparationHandler().isEnabled() && !useDijkstra) {
+            // using LM because u-turn prevention does not work properly with (node-based) CH
             landmarks = graphHopper.getLMPreparationHandler().getPreparation(profile.getName());
         } else {
             landmarks = null;

--- a/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
+++ b/matching-core/src/main/java/com/graphhopper/matching/MapMatching.java
@@ -23,10 +23,13 @@ import com.graphhopper.GraphHopper;
 import com.graphhopper.config.Profile;
 import com.graphhopper.matching.util.HmmProbabilities;
 import com.graphhopper.matching.util.TimeStep;
-import com.graphhopper.routing.DijkstraBidirectionCH;
+import com.graphhopper.routing.AStarBidirection;
 import com.graphhopper.routing.DijkstraBidirectionRef;
 import com.graphhopper.routing.Path;
 import com.graphhopper.routing.RoutingAlgorithm;
+import com.graphhopper.routing.lm.LMApproximator;
+import com.graphhopper.routing.lm.LandmarkStorage;
+import com.graphhopper.routing.lm.PrepareLandmarks;
 import com.graphhopper.routing.querygraph.QueryGraph;
 import com.graphhopper.routing.querygraph.VirtualEdgeIteratorState;
 import com.graphhopper.routing.util.DefaultEdgeFilter;
@@ -34,7 +37,6 @@ import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.RoutingCHGraphImpl;
 import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
@@ -67,16 +69,16 @@ public class MapMatching {
 
     // Penalty in m for each U-turn performed at the beginning or end of a path between two
     // subsequent candidates.
-    private double uTurnDistancePenalty;
+    private final double uTurnDistancePenalty;
 
-    private final Graph routingGraph;
+    private final Graph graph;
+    private final PrepareLandmarks landmarks;
     private final LocationIndexTree locationIndex;
     private double measurementErrorSigma = 50.0;
     private double transitionProbabilityBeta = 2.0;
     private final int maxVisitedNodes;
-    private DistanceCalc distanceCalc = new DistancePlaneProjection();
+    private final DistanceCalc distanceCalc = new DistancePlaneProjection();
     private final Weighting weighting;
-    private final boolean ch;
     private QueryGraph queryGraph;
 
     public MapMatching(GraphHopper graphHopper, PMap hints) {
@@ -115,21 +117,16 @@ public class MapMatching {
         final double headingTimePenalty = hints.getDouble(Parameters.Routing.HEADING_PENALTY, Parameters.Routing.DEFAULT_HEADING_PENALTY);
         uTurnDistancePenalty = headingTimePenalty * PENALTY_CONVERSION_VELOCITY;
 
-        boolean disableCH = hints.getBool(Parameters.CH.DISABLE, false);
-        if (graphHopper.getCHPreparationHandler().isEnabled() && disableCH && !graphHopper.getRouterConfig().isCHDisablingAllowed())
-            throw new IllegalArgumentException("Disabling CH is not allowed");
+        boolean disableLM = hints.getBool(Parameters.Landmark.DISABLE, false);
+        if (graphHopper.getLMPreparationHandler().isEnabled() && disableLM && !graphHopper.getRouterConfig().isLMDisablingAllowed())
+            throw new IllegalArgumentException("Disabling LM is not allowed");
 
-        if (graphHopper.getCHPreparationHandler().isEnabled() && !disableCH) {
-            ch = true;
-            routingGraph = graphHopper.getGraphHopperStorage().getCHGraph(profile.getName());
-            if (routingGraph == null)
-                throw new IllegalArgumentException("Cannot find CH preparation for the requested profile: '" + profile + "'" +
-                        "\nYou can try disabling CH using " + Parameters.CH.DISABLE + "=true" +
-                        "\navailable CH profiles: " + graphHopper.getGraphHopperStorage().getCHGraphNames());
+        if (graphHopper.getLMPreparationHandler().isEnabled() && !disableLM) {
+            landmarks = graphHopper.getLMPreparationHandler().getPreparation(profile.getName());
         } else {
-            ch = false;
-            routingGraph = graphHopper.getGraphHopperStorage();
+            landmarks = null;
         }
+        graph = graphHopper.getGraphHopperStorage();
         // since map matching does not support turn costs we have to disable them here explicitly
         weighting = graphHopper.createWeighting(profile, hints, true);
         this.maxVisitedNodes = hints.getInt(Parameters.Routing.MAX_VISITED_NODES, Integer.MAX_VALUE);
@@ -171,7 +168,7 @@ public class MapMatching {
         for (Collection<QueryResult> qrs : queriesPerEntry) {
             allQueryResults.addAll(qrs);
         }
-        queryGraph = QueryGraph.create(routingGraph, allQueryResults);
+        queryGraph = QueryGraph.create(graph, allQueryResults);
 
         // Different QueryResults can have the same tower node as their closest node.
         // Hence, we now dedupe the query results of each GPX entry by their closest node (#91).
@@ -454,15 +451,17 @@ public class MapMatching {
                 }
 
                 RoutingAlgorithm router;
-                if (ch) {
-                    RoutingCHGraphImpl g = new RoutingCHGraphImpl(queryGraph, weighting);
-                    router = new DijkstraBidirectionCH(g) {
+                if (landmarks != null) {
+                    AStarBidirection algo = new AStarBidirection(queryGraph, weighting, TraversalMode.NODE_BASED) {
                         @Override
                         protected void initCollections(int size) {
                             super.initCollections(50);
                         }
                     };
-                    router.setMaxVisitedNodes(maxVisitedNodes);
+                    LandmarkStorage lms = landmarks.getLandmarkStorage();
+                    int activeLM = Math.min(8, lms.getLandmarkCount());
+                    algo.setApproximation(LMApproximator.forLandmarks(queryGraph, lms, activeLM));
+                    router = algo;
                 } else {
                     router = new DijkstraBidirectionRef(queryGraph, weighting, TraversalMode.NODE_BASED) {
                         @Override
@@ -470,8 +469,8 @@ public class MapMatching {
                             super.initCollections(50);
                         }
                     };
-                    router.setMaxVisitedNodes(maxVisitedNodes);
                 }
+                router.setMaxVisitedNodes(maxVisitedNodes);
 
                 final Path path = router.calcPath(from.getQueryResult().getClosestNode(),
                         to.getQueryResult().getClosestNode());

--- a/matching-web/src/main/java/com/graphhopper/matching/cli/MeasurementCommand.java
+++ b/matching-web/src/main/java/com/graphhopper/matching/cli/MeasurementCommand.java
@@ -1,14 +1,14 @@
 /*
  *  Licensed to GraphHopper GmbH under one or more contributor
- *  license agreements. See the NOTICE file distributed with this work for 
+ *  license agreements. See the NOTICE file distributed with this work for
  *  additional information regarding copyright ownership.
- * 
- *  GraphHopper GmbH licenses this file to you under the Apache License, 
- *  Version 2.0 (the "License"); you may not use this file except in 
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
  *  compliance with the License. You may obtain a copy of the License at
- * 
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,8 +26,7 @@ import com.graphhopper.matching.MapMatching;
 import com.graphhopper.matching.MatchResult;
 import com.graphhopper.matching.Observation;
 import com.graphhopper.reader.osm.GraphHopperOSM;
-import com.graphhopper.routing.AlgorithmOptions;
-import com.graphhopper.routing.util.*;
+import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.util.*;
@@ -54,7 +53,7 @@ public class MeasurementCommand extends Command {
     private static final Logger logger = LoggerFactory.getLogger(MeasurementCommand.class);
     private final Map<String, String> properties = new TreeMap<>();
     private BBox bbox;
-    private DistanceCalcEarth distCalc = new DistanceCalcEarth();
+    private final DistanceCalcEarth distCalc = new DistanceCalcEarth();
     private long seed;
     private int count;
 
@@ -92,13 +91,13 @@ public class MeasurementCommand extends Command {
         GraphHopper graphHopper = new GraphHopperOSM();
         graphHopper.init(graphHopperConfiguration).forDesktop();
         graphHopper.importOrLoad();
-        
+
         // and map-matching stuff
         GraphHopperStorage graph = graphHopper.getGraphHopperStorage();
         bbox = graph.getBounds();
         LocationIndexTree locationIndex = (LocationIndexTree) graphHopper.getLocationIndex();
         MapMatching mapMatching = new MapMatching(graphHopper, new PMap().putObject("profile", "fast_car"));
-        
+
         // start tests:
         StopWatch sw = new StopWatch().start();
         try {
@@ -134,7 +133,6 @@ public class MeasurementCommand extends Command {
     /**
      * Test the performance of finding candidate points for the index (which is run for every GPX
      * entry).
-     * 
      */
     private void printLocationIndexMatchQuery(final LocationIndexTree idx) {
         final double latDelta = bbox.maxLat - bbox.minLat;

--- a/matching-web/src/test/java/com/graphhopper/matching/MapMatching2Test.java
+++ b/matching-web/src/test/java/com/graphhopper/matching/MapMatching2Test.java
@@ -19,7 +19,7 @@ package com.graphhopper.matching;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.graphhopper.GraphHopper;
-import com.graphhopper.config.CHProfile;
+import com.graphhopper.config.LMProfile;
 import com.graphhopper.config.Profile;
 import com.graphhopper.matching.gpx.Gpx;
 import com.graphhopper.reader.osm.GraphHopperOSM;
@@ -60,8 +60,8 @@ public class MapMatching2Test {
         hopper.setGraphHopperLocation(GH_LOCATION);
         hopper.setEncodingManager(EncodingManager.create(encoder));
         hopper.setProfiles(new Profile("my_profile").setVehicle("car").setWeighting("fastest"));
-        hopper.getCHPreparationHandler().setCHProfiles(new CHProfile("my_profile"));
-        hopper.getRouterConfig().setCHDisablingAllowed(true);
+        hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("my_profile"));
+        hopper.getRouterConfig().setLMDisablingAllowed(true);
         hopper.importOrLoad();
 
         MapMatching mapMatching = new MapMatching(hopper, new PMap().putObject("profile", "my_profile"));
@@ -92,8 +92,8 @@ public class MapMatching2Test {
         hopper.setGraphHopperLocation(GH_LOCATION);
         hopper.setEncodingManager(EncodingManager.create(encoder));
         hopper.setProfiles(new Profile("my_profile").setVehicle("car").setWeighting("fastest"));
-        hopper.getCHPreparationHandler().setCHProfiles(new CHProfile("my_profile"));
-        hopper.getRouterConfig().setCHDisablingAllowed(true);
+        hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("my_profile"));
+        hopper.getRouterConfig().setLMDisablingAllowed(true);
         hopper.importOrLoad();
 
         MapMatching mapMatching = new MapMatching(hopper, new PMap().putObject("profile", "my_profile"));
@@ -119,8 +119,8 @@ public class MapMatching2Test {
         hopper.setGraphHopperLocation(GH_LOCATION);
         hopper.setEncodingManager(EncodingManager.create(encoder));
         hopper.setProfiles(new Profile("my_profile").setVehicle("car").setWeighting("fastest"));
-        hopper.getCHPreparationHandler().setCHProfiles(new CHProfile("my_profile"));
-        hopper.getRouterConfig().setCHDisablingAllowed(true);
+        hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("my_profile"));
+        hopper.getRouterConfig().setLMDisablingAllowed(true);
         hopper.importOrLoad();
 
         MapMatching mapMatching = new MapMatching(hopper, new PMap().putObject("profile", "my_profile"));

--- a/matching-web/src/test/java/com/graphhopper/matching/MapMatchingTest.java
+++ b/matching-web/src/test/java/com/graphhopper/matching/MapMatchingTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.graphhopper.GHRequest;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.ResponsePath;
-import com.graphhopper.config.CHProfile;
+import com.graphhopper.config.LMProfile;
 import com.graphhopper.config.Profile;
 import com.graphhopper.matching.gpx.Gpx;
 import com.graphhopper.reader.osm.GraphHopperOSM;
@@ -71,8 +71,8 @@ public class MapMatchingTest {
         graphHopper.setGraphHopperLocation(GH_LOCATION);
         graphHopper.setEncodingManager(EncodingManager.create(encoder));
         graphHopper.setProfiles(new Profile("my_profile").setVehicle("car").setWeighting("fastest"));
-        graphHopper.getCHPreparationHandler().setCHProfiles(new CHProfile("my_profile"));
-        graphHopper.getRouterConfig().setCHDisablingAllowed(true);
+        graphHopper.getLMPreparationHandler().setLMProfiles(new LMProfile("my_profile"));
+        graphHopper.getRouterConfig().setLMDisablingAllowed(true);
         graphHopper.importOrLoad();
     }
 
@@ -84,8 +84,8 @@ public class MapMatchingTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> algoOptions() {
         return Arrays.asList(new Object[][]{
-                {"non-CH", new PMap().putObject(Parameters.CH.DISABLE, true)},
-                {"CH", new PMap().putObject(Parameters.CH.DISABLE, false)}
+                {"non-LM", new PMap().putObject(Parameters.Landmark.DISABLE, true)},
+                {"LM", new PMap().putObject(Parameters.Landmark.DISABLE, false)}
         });
     }
 

--- a/matching-web/src/test/java/com/graphhopper/matching/RoutingAdditivityTest.java
+++ b/matching-web/src/test/java/com/graphhopper/matching/RoutingAdditivityTest.java
@@ -21,7 +21,7 @@ package com.graphhopper.matching;
 import com.graphhopper.GHRequest;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.ResponsePath;
-import com.graphhopper.config.CHProfile;
+import com.graphhopper.config.LMProfile;
 import com.graphhopper.config.Profile;
 import com.graphhopper.reader.osm.GraphHopperOSM;
 import com.graphhopper.routing.util.CarFlagEncoder;
@@ -53,8 +53,8 @@ public class RoutingAdditivityTest {
         graphHopper.setGraphHopperLocation(GH_LOCATION);
         graphHopper.setEncodingManager(EncodingManager.create(encoder));
         graphHopper.setProfiles(new Profile("my_profile").setVehicle("car").setWeighting("fastest"));
-        graphHopper.getCHPreparationHandler().setCHProfiles(new CHProfile("my_profile"));
-        graphHopper.getRouterConfig().setCHDisablingAllowed(true);
+        graphHopper.getLMPreparationHandler().setLMProfiles(new LMProfile("my_profile"));
+        graphHopper.getRouterConfig().setLMDisablingAllowed(true);
         graphHopper.importOrLoad();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <slf4j.version>1.7.26</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
-        <gh.version>41b0c28ed254e04bedb0e23e178527140eac82fb</gh.version>
+        <gh.version>4546904fcf647de8f0c08fbaf2eb8e3c600db1d4</gh.version>
 
         <dropwizard.version>2.0.8</dropwizard.version>
         <jackson.version>2.10.3</jackson.version>


### PR DESCRIPTION
Using (node-based) CH for map-matching is problematic because the way we are currently preventing u-turns (using unfavored edges in QueryGraph) yields different results than Dijkstra routing as it introduces u-turns at the tower nodes next to the virtual nodes. Its the same problem as with heading+CH, see https://github.com/graphhopper/graphhopper/issues/1647.

Another issue is that map matching with CH is not even necessarily faster than Dijkstra and in fact can be *much* slower. This strongly depends on the distance between the input points. If the GPX data is dense using Dijkstra is much faster, while for sparse GPX data CH can be much faster (and in fact Dijkstra could be prohibitively slow in this scenario). 

In this PR I have replaced CH with LM. Possible future improvements would be:

- Use the airline distance to decide whether to use LM/CH or plain Dijkstra for every segment of the route to choose the optimal algorithm depending on the distance

- Use edge-based routing to account for turn costs. Also this would allow us to use (this time edge-based) CH again and properly handle u-turns at the GPX points.